### PR TITLE
Provide placeholder for return definitions

### DIFF
--- a/snippets/language-go.cson
+++ b/snippets/language-go.cson
@@ -4,7 +4,7 @@
     'body': 'import "${1:fmt}"'
   'func':
     'prefix': 'func'
-    'body': "func $1($2) {\n\t$0\n}"
+    'body': "func $1($2) $3 {\n\t$0\n}"
   'main':
     'prefix': 'main'
     'body': "func main() {\n\t$1\n}"


### PR DESCRIPTION
function declarations often have a return type as well as parameters.  This just provides a place to put them.
