### PR TITLE
:lipstick: Default To Line-Comments Style - Fixes #16

### DIFF
--- a/scoped-properties/language-go.cson
+++ b/scoped-properties/language-go.cson
@@ -1,0 +1,3 @@
+'.source.go':
+  'editor':
+    'commentStart': '// '


### PR DESCRIPTION
See #16. References supporting the desire to prefer `//` over `/* ... */`:
- http://blog.golang.org/godoc-documenting-go-code
- https://code.google.com/p/go-wiki/wiki/CodeReviewComments
- http://golang.org/doc/effective_go.html#commentary

In summary, the vast majority of your comments are likely to be line-style. Block-style comments may occasionally be seen in package comments, but even then only in non-trivial packages (likely with examples).

Consequently, `//` would be preferable as it is most commonly used, and it would be nice if we had another keyboard shortcut for `/* ... */`?
