### PR TITLE
Improve handling of multiline "var" declarations

### DIFF
--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -53,39 +53,6 @@
     'match': '^(func)(\\s+(\\([^\\)]+\\)\\s+)?([\\w_][\\w_\\d]*)(?=\\())?'
   }
   {
-    'comment': 'var statements, single-line or the opening of a multi-line.'
-    'begin': '^\\s*(var)\\s+'
-    'beginCaptures':
-      '1':
-        'name': 'keyword.go'
-    'end': '\\(|='
-    'endCaptures':
-      '0':
-        'name': 'keyword.operator.go'
-    'patterns': [
-      {
-        'match': '([\\w_][\\w\\d_]*)\\s+([\\w_][\\w\\d_]*)'
-        'captures':
-          '1':
-            'name': 'variable.go'
-          '2':
-            'name': 'storage.type.go'
-      }
-      {
-        'match': '([\\w_][\\w\\d_]*)\\s*(,)'
-        'captures':
-          '1':
-            'name': 'variable.go'
-          '2':
-            'name': 'keyword.operator.go'
-      }
-      {
-        'match': '[\\w_][\\w\\d_]*'
-        'name': 'variable.go'
-      }
-    ]
-  }
-  {
     'comment': 'Short declarations'
     'match': '([\\w_][\\w\\d_]*)(?=\\s*:=)'
     'captures':
@@ -164,15 +131,6 @@
   {
     'name': 'support.function.built-in.go'
     'match': '\\b(append|cap|close|complex|copy|delete|imag|len|make|new|panic|print|println|real|recover)\\b'
-  }
-  {
-    'comment': 'Variable declaration followed by an explicit type'
-    'match': '([\\w_][\\w\\d_]*)\\s+([\\w_*\\[\\]][\\w\\d_*\\[\\]]*)'
-    'captures':
-      '1':
-        'name': 'variable.go'
-      '2':
-        'name': 'storage.type.go'
   }
   {
     'match': '\\b[\\w_][\\w\\d_]*\\b'

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -364,7 +364,7 @@ describe 'Go grammar', ->
         {tokens} = grammar.tokenizeLine 'var z blub = 7'
         testVar tokens[0]
         testName tokens[2], 'z'
-        testType tokens[4], 'blub'
+        testName tokens[4], 'blub'
         testOp tokens[6], '='
         testNum tokens[8], '7'
 
@@ -425,7 +425,8 @@ describe 'Go grammar', ->
           testVar kwd[1]
           testOp kwd[3], '('
           testName decl[1], 'foo'
-          testType decl[3], '*bar'
+          testOp decl[3], '*'
+          testName decl[4], 'bar'
           testOp closing[1], ')'
 
         it 'tokenizes single names with an initializer', ->


### PR DESCRIPTION
I'm looking into ways to improve the handling of `var ()` declarations like these ones:

There are a number of issues here:

![screen shot 2014-08-22 at 11 33 15 am](https://cloud.githubusercontent.com/assets/17565/4013584/d4a8cfa4-2a17-11e4-9f92-a3b5664eb256.png)

![screen shot 2014-08-22 at 12 00 26 pm](https://cloud.githubusercontent.com/assets/17565/4013588/e68b116e-2a17-11e4-855e-b35f52f6d286.png)
- The closing `)` isn't highlighted (not as obvious with this syntax theme).
- Initialization expressions on the right-hand sides of assignments are not highlighted correctly.
- If you add a `var (` expression in an existing file, the rest of the file will be highlighted incorrectly until you put the closing `)` on its own line and re-trigger highlighting.
- Types are lexed as variable names, even in the simpler `var x int`-style declarations.

The relevant part of the Go spec is [here](https://golang.org/ref/spec#Variable_declarations).

Interestingly, `const` and `import` don't seem to have the same issues.

re #27
