### PR TITLE
Fix grammer of built-in functions and their data types

### DIFF
--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -76,6 +76,15 @@
     'match': '\\b(chan|map|bool|string|error|int|int8|int16|int32|int64|rune|byte|uint|uint8|uint16|uint32|uint64|uintptr|float32|float64|complex64|complex128)\\b'
   }
   {
+    'comment': 'Built-in functions & their argument types'
+    'match': '\\b(append|cap|close|complex|copy|delete|imag|len|make|new|panic|print|println|real|recover)\\b(\\()(\\S*(?=\\)))'
+    'captures':
+      '1':
+        'name': 'support.function.built-in.go'
+      '3':
+        'name': 'storage.type.go'
+  }
+  {
     'name': 'support.function.go'
     'match': '([\\w_][\\w\\d_]*)(?=\\()'
   }
@@ -127,10 +136,6 @@
   }
   {
     'include': '#operators'
-  }
-  {
-    'name': 'support.function.built-in.go'
-    'match': '\\b(append|cap|close|complex|copy|delete|imag|len|make|new|panic|print|println|real|recover)\\b'
   }
   {
     'match': '\\b[\\w_][\\w\\d_]*\\b'

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -215,13 +215,15 @@ describe 'Go grammar', ->
 
   it 'tokenizes built-in functions', ->
     funcs = [
-      'append', 'cap', 'close', 'complex', 'copy', 'delete', 'imag', 'len', 'make', 'new',
-      'panic', 'print', 'println', 'real', 'recover'
+      'append(x)', 'cap(x)', 'close(x)', 'complex(x)', 'copy(x)', 'delete(x)', 'imag(x)', 'len(x)', 'make(x)', 'new(x)',
+      'panic(x)', 'print(x)', 'println(x)', 'real(x)', 'recover(x)'
     ]
-
+    funcVals = ['append', 'cap', 'close', 'complex', 'copy', 'delete', 'imag', 'len', 'make', 'new', 'panic', 'print', 'println', 'real', 'recover']
+    
     for func in funcs
+      funcVal = funcVals[funcs.indexOf(func)]
       {tokens} = grammar.tokenizeLine func
-      expect(tokens[0].value).toEqual func
+      expect(tokens[0].value).toEqual funcVal
       expect(tokens[0].scopes).toEqual ['source.go', 'support.function.built-in.go']
 
   it 'tokenizes operators', ->


### PR DESCRIPTION
Built-in function keywords weren't being properly detected because they were below the `functions` object. 
Also added support for these keywords' arguments to be named as `storage.type.go`.