### PR TITLE
Add print verbs recognition in raw quotes and fix rune (single quote string) recognition

### DIFF
--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -85,6 +85,10 @@
         'name': 'support.function.go'
   }
   {
+    'name': 'constant.rune.go'
+    'match': '\\\'(\\\\([0-7]{3}|[abfnrtv\\\\\'"]|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8})|\\\p{Any})\\\''
+  }
+  {
     'name': 'invalid.illegal.numeric.go'
     'match': '\\b0[0-7]*[89]\\d*\\b'
   }
@@ -212,22 +216,6 @@
         'patterns': [
           {
             'include': '#printf_verbs'
-          }
-        ]
-      }
-      {
-        'begin': '\''
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.string.begin.go'
-        'end': '\''
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.string.end.go'
-        'name': 'string.quoted.single.go'
-        'patterns': [
-          {
-            'include': '#string_escaped_char'
           }
         ]
       }

--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -204,16 +204,14 @@
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.string.begin.go'
-        'end': '((?<=`)(`)|`)'
+        'end': '`'
         'endCaptures':
-          '1':
+          '0':
             'name': 'punctuation.definition.string.end.go'
-          '2':
-            'name': 'meta.empty-string.double.go'
-        'name': 'string.quoted.double.raw.backtick.go',
+        'name': 'string.quoted.raw.go',
         'patterns': [
           {
-            'include': 'source.gotemplate'
+            'include': '#printf_verbs'
           }
         ]
       }

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -30,7 +30,6 @@ describe 'Go grammar', ->
   it 'tokenizes strings', ->
     delims =
       'string.quoted.double.go': '"'
-      'string.quoted.single.go': '\''
       'string.quoted.raw.go': '`'
 
     for scope, delim of delims
@@ -76,10 +75,6 @@ describe 'Go grammar', ->
     expect(tokens[1].value).toEqual '\\"'
     expect(tokens[1].scopes).toEqual ['source.go', 'string.quoted.double.go', 'constant.character.escape.go']
 
-    {tokens} = grammar.tokenizeLine('\'\\\'\'')
-    expect(tokens[1].value).toEqual '\\\'',
-    expect(tokens[1].scopes).toEqual ['source.go', 'string.quoted.single.go', 'constant.character.escape.go']
-
   it 'tokenizes Printf verbs in raw strings', ->
     # Taken from go/src/pkg/fmt/fmt_test.go
     verbs = [
@@ -98,6 +93,19 @@ describe 'Go grammar', ->
       expect(tokens[1].scopes).toEqual ['source.go', 'string.quoted.raw.go', 'constant.escape.format-verb.go']
       expect(tokens[2].value).toEqual '`',
       expect(tokens[2].scopes).toEqual ['source.go', 'string.quoted.raw.go', 'punctuation.definition.string.end.go']
+
+  it 'tokenizes runes', ->
+    # Taken from go/src/pkg/fmt/fmt_test.go
+    verbs = [
+      'u', 'X', '$', ':', '(', '.', '2', '=', '!', '@',
+      '\\a', '\\b', '\\f', '\\n', '\\r', '\\t', '\\v', '\\\\'
+      '\\000', '\\007', '\\377', '\\x07', '\\xff', '\\u12e4', '\\U00101234'
+    ]
+
+    for verb in verbs
+      {tokens} = grammar.tokenizeLine('\'' + verb + '\'')
+      expect(tokens[0].value).toEqual '\'' + verb + '\'',
+      expect(tokens[0].scopes).toEqual ['source.go', 'constant.rune.go']
 
   it 'tokenizes invalid whitespace around chan annotations', ->
     invalids =

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -31,7 +31,7 @@ describe 'Go grammar', ->
     delims =
       'string.quoted.double.go': '"'
       'string.quoted.single.go': '\''
-      'string.quoted.double.raw.backtick.go': '`'
+      'string.quoted.raw.go': '`'
 
     for scope, delim of delims
       {tokens} = grammar.tokenizeLine(delim + 'I am a string' + delim)
@@ -79,6 +79,25 @@ describe 'Go grammar', ->
     {tokens} = grammar.tokenizeLine('\'\\\'\'')
     expect(tokens[1].value).toEqual '\\\'',
     expect(tokens[1].scopes).toEqual ['source.go', 'string.quoted.single.go', 'constant.character.escape.go']
+
+  it 'tokenizes Printf verbs in raw strings', ->
+    # Taken from go/src/pkg/fmt/fmt_test.go
+    verbs = [
+      '%# x', '%-5s', '%5s', '%05s', '%.5s', '%10.1q', '%10v', '%-10v', '%.0d'
+      '%.d', '%+07.2f', '%0100d', '%0.100f', '%#064x', '%+.3F', '%-#20.8x',
+      '%[1]d', '%[2]*[1]d', '%[3]*.[2]*[1]f', '%[3]*.[2]f', '%3.[2]d', '%.[2]d'
+      '%-+[1]x', '%d', '%-d', '%+d', '%#d', '% d', '%0d', '%1.2d', '%-1.2d'
+      '%+1.2d', '%-+1.2d', '%*d', '%.*d', '%*.*d', '%0*d', '%-*d'
+    ]
+
+    for verb in verbs
+      {tokens} = grammar.tokenizeLine('`' + verb + '`')
+      expect(tokens[0].value).toEqual '`',
+      expect(tokens[0].scopes).toEqual ['source.go', 'string.quoted.raw.go', 'punctuation.definition.string.begin.go']
+      expect(tokens[1].value).toEqual verb
+      expect(tokens[1].scopes).toEqual ['source.go', 'string.quoted.raw.go', 'constant.escape.format-verb.go']
+      expect(tokens[2].value).toEqual '`',
+      expect(tokens[2].scopes).toEqual ['source.go', 'string.quoted.raw.go', 'punctuation.definition.string.end.go']
 
   it 'tokenizes invalid whitespace around chan annotations', ->
     invalids =


### PR DESCRIPTION
This time exactly according to the Go language specs.... As for the details, again the same two screenshots (the print verbs changes are according to the specs but the escaped chars part wasn't so removed that part). 

Before:
![image](https://cloud.githubusercontent.com/assets/4171547/7101386/dca5d200-e057-11e4-8ad9-320bf5815b4f.png)

After:
![image](https://cloud.githubusercontent.com/assets/4171547/7101379/868c2428-e057-11e4-9874-c08689dab65c.png)