### PR TITLE
Updating/fixing the rune matching

### DIFF
--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -85,10 +85,6 @@
         'name': 'support.function.go'
   }
   {
-    'name': 'constant.rune.go'
-    'match': '\\\'(\\\\([0-7]{3}|[abfnrtv\\\\\'"]|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8})|\\\p{Any})\\\''
-  }
-  {
     'name': 'invalid.illegal.numeric.go'
     'match': '\\b0[0-7]*[89]\\d*\\b'
   }
@@ -133,6 +129,9 @@
   }
   {
     'include': '#strings'
+  }
+  {
+    'include': '#runes'
   }
   {
     'include': '#operators'
@@ -218,5 +217,16 @@
             'include': '#printf_verbs'
           }
         ]
+      }
+    ]
+  'runes':
+    'patterns': [
+      {
+        'match': '\\\'(\\\\([0-7]{3}|[abfnrtv\\\\\'"]|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8})|\\\p{Any})\\\''
+        'name': 'constant.other.rune.go'
+      }
+      {
+        'match': '\\\'.*\\\''
+        'name': 'invalid.illegal.rune.go'
       }
     ]

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -95,7 +95,6 @@ describe 'Go grammar', ->
       expect(tokens[2].scopes).toEqual ['source.go', 'string.quoted.raw.go', 'punctuation.definition.string.end.go']
 
   it 'tokenizes runes', ->
-    # Taken from go/src/pkg/fmt/fmt_test.go
     verbs = [
       'u', 'X', '$', ':', '(', '.', '2', '=', '!', '@',
       '\\a', '\\b', '\\f', '\\n', '\\r', '\\t', '\\v', '\\\\'
@@ -105,7 +104,16 @@ describe 'Go grammar', ->
     for verb in verbs
       {tokens} = grammar.tokenizeLine('\'' + verb + '\'')
       expect(tokens[0].value).toEqual '\'' + verb + '\'',
-      expect(tokens[0].scopes).toEqual ['source.go', 'constant.rune.go']
+      expect(tokens[0].scopes).toEqual ['source.go', 'constant.other.rune.go']
+
+  it 'tokenizes invalid runes and single quote strings', ->
+    {tokens} = grammar.tokenizeLine('\'ab\'')
+    expect(tokens[0].value).toEqual '\'ab\''
+    expect(tokens[0].scopes).toEqual ['source.go', 'invalid.illegal.rune.go']
+
+    {tokens} = grammar.tokenizeLine('\'some single quote string\'')
+    expect(tokens[0].value).toEqual '\'some single quote string\''
+    expect(tokens[0].scopes).toEqual ['source.go', 'invalid.illegal.rune.go']
 
   it 'tokenizes invalid whitespace around chan annotations', ->
     invalids =


### PR DESCRIPTION
The class `constant.rune` is not generally available in themes as the name `rune` is more of less Go language specific. So renamed the class to `constant.other.rune` which then is matched against `constant.other` which does seem to be general available.

Also added some more testing and matching to invalidate any other uses of single quoted strings following the language specs.

P.S. Sorry to have another PR already, but this improves the rune related stuff quite a bit making it more robuust and inline with the language specs.