### PR TITLE
Fixes #31 and #41

### DIFF
--- a/settings/language-go.cson
+++ b/settings/language-go.cson
@@ -1,5 +1,5 @@
 '.source.go':
   'editor':
     'commentStart': '// '
-    'increaseIndentPattern': '^.*(\\bcase\\b.*:|\\bdefault\\b:|(\\b(func|if|else|switch|select|for|struct)\\b.*|\\w)\\{[^}]*|\\([^)]*|\\+)$'
+    'increaseIndentPattern': '^.*(\\bcase\\b.*:|\\bdefault\\b:|(\\b(func|if|else|switch|select|for|struct)\\b.*|\\w)\\{[^}]*|\\([^)]*)$'
     'decreaseIndentPattern': '^\\s*(\\bcase\\b.*:|\\bdefault\\b:|\\}[),]?|\\))$'

--- a/settings/language-go.cson
+++ b/settings/language-go.cson
@@ -1,3 +1,5 @@
 '.source.go':
   'editor':
     'commentStart': '// '
+    'increaseIndentPattern': '^.*(case.*:|default:|((func|if|else|switch|select|for|struct).*|\\w)\\{[^}]*|\\([^)]*|\\+)$'
+    'decreaseIndentPattern': '^\\s*(case.*:|default:|\\}[),]?|\\))$'

--- a/settings/language-go.cson
+++ b/settings/language-go.cson
@@ -1,5 +1,5 @@
 '.source.go':
   'editor':
     'commentStart': '// '
-    'increaseIndentPattern': '^.*(case.*:|default:|((func|if|else|switch|select|for|struct).*|\\w)\\{[^}]*|\\([^)]*|\\+)$'
-    'decreaseIndentPattern': '^\\s*(case.*:|default:|\\}[),]?|\\))$'
+    'increaseIndentPattern': '^.*(\\bcase\\b.*:|\\bdefault\\b:|(\\b(func|if|else|switch|select|for|struct)\\b.*|\\w)\\{[^}]*|\\([^)]*|\\+)$'
+    'decreaseIndentPattern': '^\\s*(\\bcase\\b.*:|\\bdefault\\b:|\\}[),]?|\\))$'


### PR DESCRIPTION
I know at least two [1][2] corner cases which are still not 100% after adding this fix. But those corner cases require a tweak to Atom itself. This has to do with the need for an option to decrease the indent level
based on the previous line, which currently is not supported in Atom.

Take this use case:

```
s := fmt.Sprint(“some” +
  “thing”)
  fmt.Print(s)
```

[1] The indentation for this is now done correctly for the first line, but only if you press enter after the `+` sign while the statement is already complete (so `"thing")` is on the same line already. But if you type this in (which is of course expected behaviour) and while typing you hit enter right after the `+` sign with only a `)` behind the cursor, it will not indent.

This is correct as a single `)` on a line is closing an earlier opened `(` and should have a decreased indent level assuming there are indented lines in between. But then as soon as you start typing `"thing"` it should indent, because it no longer is a single `)`. Atom currently has no way to do this. It can do this for decreasing indents (like you can see with `case` in a `switch` statement, but not for increasing indents.

[2] Next to that the last line should have a decreased indent level. But again given the current options Atom give us there is no way to do this as decreasing the indent should be based on the previous line instead of the current.

Will look into Atom core to see if I can extend the possibilities so we can also fix the last corner cases.

Nevertheless I would like to get this one in before that, as it fixes a few open issues and gives others the option to test and maybe extend (if they find new corner cases) the regexes.