### PR TITLE
Adding new regexp to improve indentations

### DIFF
--- a/settings/language-go.cson
+++ b/settings/language-go.cson
@@ -2,4 +2,5 @@
   'editor':
     'commentStart': '// '
     'increaseIndentPattern': '^.*(\\bcase\\b.*:|\\bdefault\\b:|(\\b(func|if|else|switch|select|for|struct)\\b.*|\\w)\\{[^}]*|\\([^)]*)$'
+    'decreaseNextIndentPattern': '^\\s*[^\\s()}]+(?<m>[^()]*\\((?:\\g<m>|[^()]*)\\)[^()]*)*[^()]*\\)$'
     'decreaseIndentPattern': '^\\s*(\\bcase\\b.*:|\\bdefault\\b:|\\}[),]?|\\))$'


### PR DESCRIPTION
As discussed earlier in PR #43, we need to extend the current options Atom has to determine what the correct indent level should be.

For this I created PR https://github.com/atom/atom/pull/6808 but in order to be able to write a proper test, I need at least one language package to include the new regexp so I can call it in the test.

So this is a little like the chicken and the egg. This new regexp will not currently be used by anything else than the tests and depending on the outcome of that PR it could need a refactor and or name change. But without adding this now and updating the version number in Atom for this package, I will not be able to finish the tests needed to get that PR merged.

So it would be very nice if we can merge this and cut a new release on it. Note that this will change nothing for all existing users of this package and is fully backwards compatible.