### PR TITLE
Updated the name to be more inline with TextMate

### DIFF
--- a/settings/language-go.cson
+++ b/settings/language-go.cson
@@ -2,5 +2,5 @@
   'editor':
     'commentStart': '// '
     'increaseIndentPattern': '^.*(\\bcase\\b.*:|\\bdefault\\b:|(\\b(func|if|else|switch|select|for|struct)\\b.*|\\w)\\{[^}]*|\\([^)]*)$'
-    'decreaseNextIndentPattern': '^\\s*[^\\s()}]+(?<m>[^()]*\\((?:\\g<m>|[^()]*)\\)[^()]*)*[^()]*\\)$'
     'decreaseIndentPattern': '^\\s*(\\bcase\\b.*:|\\bdefault\\b:|\\}[),]?|\\))$'
+    'dedentNextLinePattern': '^\\s*[^\\s()}]+(?<m>[^()]*\\((?:\\g<m>|[^()]*)\\)[^()]*)*[^()]*\\)$'


### PR DESCRIPTION
After having quite some discussions and improvements it seems we are now in the final stages of getting
https://github.com/atom/atom/pull/6808 merged.

One thing remaining is that we decided to revert some names and update this name. So it would be really nice if we can get this one merged and released asap, so I can make the final update to https://github.com/atom/atom/pull/6808 in order to let @maxbrunsfeld press the big green button :wink: