### PR TITLE
added snipppet "fmt printf" for printing via %+v

### DIFF
--- a/snippets/language-go.cson
+++ b/snippets/language-go.cson
@@ -62,6 +62,9 @@
   'fmt println':
     'prefix': 'fp'
     'body': "fmt.Println(\"$1\")$0"
+  'fmt printf':
+    'prefix': 'ff'
+    'body': "fmt.Printf(\"$1  %+v \\\\n\", ${1:e})$0"
   'log println':
     'prefix': 'lp'
     'body': "log.Println(\"$1\")$0"

--- a/snippets/language-go.cson
+++ b/snippets/language-go.cson
@@ -64,7 +64,7 @@
     'body': "fmt.Println(\"$1\")$0"
   'fmt printf':
     'prefix': 'ff'
-    'body': "fmt.Printf(\"$1  %+v \\\\n\", ${1:e})$0"
+    'body': "fmt.Printf(\"$1  %#+v \\\\n\", ${1:e})$0"
   'log println':
     'prefix': 'lp'
     'body': "log.Println(\"$1\")$0"


### PR DESCRIPTION
Adding a snippet for printf with "%+v" for printing out non-strings. The snippet is:

    'body': "fmt.Printf(\"$1  %+v \\\\n\", ${1:e})$0"

Which translates to:

    fmt.Printf("someVar  %+v \n", someVar)

