### PR TITLE
Generalising and tweaking snippets

### DIFF
--- a/snippets/language-go.cson
+++ b/snippets/language-go.cson
@@ -1,118 +1,121 @@
 '.source.go':
-  'import':
+  'package clause':
+    'prefix': 'pkg'
+    'body': "package ${1:name}"
+  'single import':
     'prefix': 'im'
-    'body': 'import "${1:fmt}"'
-  'func':
+    'body': 'import "${1:package}"'
+  'multiple imports':
+    'prefix': 'ims'
+    'body': "import (\n\t\"${1:package}\"\n)"
+  'single constant':
+    'prefix': 'co'
+    'body': "const ${1:name} = ${2:value}"
+  'multiple constants':
+    'prefix': 'cos'
+    'body': "const (\n\t\"${1:name} = {2:value}\"\n)"
+  'type interface declaration':
+    'prefix': 'tyi'
+    'body': "type ${1:name} interface {\n\t$0\n}"
+  'type struct declaration':
+    'prefix': 'tys'
+    'body': "type ${1:name} struct {\n\t$0\n}"
+  'main function':
+    'prefix': 'main'
+    'body': "func main() {\n\t$0\n}"
+  'function declaration':
     'prefix': 'func'
     'body': "func $1($2) $3 {\n\t$0\n}"
-  'main':
-    'prefix': 'main'
-    'body': "func main() {\n\t$1\n}"
-  'var':
+  'variable declaration':
     'prefix': 'var'
-    'body': "var ${1:ok} ${2:bool}$0"
-  'switch':
+    'body': "var ${1:name} ${2:type}"
+  'switch statement':
     'prefix': 'switch'
-    'body': "switch ${1:value} {\ncase ${2:cond}:\n\t$0\n}"
-  'Import':
-    'prefix': 'Im'
-    'body': "import (\n\t\"${1:fmt}\"\n)$0"
-  'package':
-    'prefix': 'pkg'
-    'body': "package ${1:main}"
-  'type interface':
-    'prefix': 'tyi'
-    'body': "type ${1:Name} interface {\n\t$0\n}"
-  'type struct':
-    'prefix': 'tys'
-    'body': "type ${1:Name} struct {\n\t$0\n}"
-  'for range':
+    'body': "switch ${1:expression} {\ncase ${2:condition}:\n\t$0\n}"
+  'case clause':
+    'prefix': 'cs'
+    'body': "case ${1:condition}:$0"
+  'for statement':
+    'prefix': 'for'
+    'body':  "for ${1:index} := 0; $1 < ${2:count}; $1${3:++} {\n\t$0\n}"
+  'for range statement':
     'prefix': 'forr'
-    'body': "for ${1:index}, ${2:item} := range ${3:list} {\n\t$0\n}"
+    'body': "for ${1:var} := range ${2:var} {\n\t$0\n}"
+  'channel declaration':
+    'prefix': 'ch'
+    'body': "chan ${1:type}"
+  'map declaration':
+    'prefix': 'map'
+    'body': "map[${1:type}]${2:type}"
+  'empty interface':
+    'prefix': 'in'
+    'body': "interface{}"
+  'if statement':
+    'prefix': 'if'
+    'body': "if ${1:condition} {\n\t$0\n}"
+  'else branch':
+    'prefix': 'el'
+    'body': "else {\n\t$0\n}"
+  'if else statement':
+    'prefix': 'ie'
+    'body': "if ${1:condition} {\n\t$2\n} else {\n\t$0\n}"
   'if err != nil':
     'prefix': 'iferr'
     'body': "if err != nil {\n\t${1:return}\n}"
-  'channel':
-    'prefix': 'ch'
-    'body': "chan ${0:int}"
-  'case':
-    'prefix': 'cs'
-    'body': "case ${1:value}:$0"
-  'const':
-    'prefix': 'c'
-    'body': "const ${1:NAME} = ${0:0}"
-  'defer':
-    'prefix': 'df'
-    'body': "defer ${0:func}()"
-  'interface':
-    'prefix': 'in'
-    'body': "interface{}"
-  'if':
-    'prefix': 'if'
-    'body': "if ${1:condition} {\n\t$2\n}"
-  'else':
-    'prefix': 'el'
-    'body': "else {\n\t$1\n}"
-  'if else':
-    'prefix': 'ie'
-    'body': "if ${1:condition} {\n\t$2\n} else {\n\t$3\n}\n$0"
-  'for':
-    'prefix': 'for'
-    'body':  "for ${2:index} := 0; $2 < ${1:count}; $2${3:++} {\n\t$4\n}\n$0"
-  'fmt println':
+  'fmt.Println':
     'prefix': 'fp'
-    'body': "fmt.Println(\"$1\")$0"
-  'fmt printf':
+    'body': "fmt.Println(\"$1\")"
+  'fmt.Printf':
     'prefix': 'ff'
-    'body': "fmt.Printf(\"$1\", ${2:value})$0"
-  'log println':
+    'body': "fmt.Printf(\"$1\", ${2:var})"
+  'log.Println':
     'prefix': 'lp'
-    'body': "log.Println(\"$1\")$0"
-  'log printf':
+    'body': "log.Println(\"$1\")"
+  'log.Printf':
     'prefix': 'lf'
-    'body': "log.Printf(\"$1\", ${2:value})$0"
+    'body': "log.Printf(\"$1\", ${2:var})"
   'log variable content':
     'prefix': 'lv'
-    'body': "log.Printf(\"$1: %#+v\\\\n\", ${1:value})$0"
-  'make':
+    'body': "log.Printf(\"${1:var}: %#+v\\\\n\", ${1:var})"
+  'make(...)':
     'prefix': 'make'
-    'body': "make(${1:[]string}, ${0:0})"
-  'map':
-    'prefix': 'map'
-    'body': "map[${1:string}]${0:int}"
-  'new':
+    'body': "make(${1:type}, ${2:0})"
+  'new(...)':
     'prefix': 'new'
-    'body': "new(${0:type})"
-  'panic':
+    'body': "new(${1:type})"
+  'panic(...)':
     'prefix': 'pn'
-    'body': "panic(\"${0:message}\")"
-  'http responsewriter request':
+    'body': "panic(\"$0\")"
+  'http ResponseWriter *Request':
     'prefix': 'wr'
     'body': "${1:w} http.ResponseWriter, ${2:r} *http.Request"
-  'handlerfunc':
+  'http.HandleFunc':
     'prefix': 'hf'
-    'body': "${1:http}.HandleFunc(\"${2:/}\", ${3:handler})\n"
-  'handler':
+    'body': "${1:http}.HandleFunc(\"${2:/}\", ${3:handler})"
+  'http handler declaration':
     'prefix': 'hand'
-    'body': "func ${1:nameHandler}(${2:w} http.ResponseWriter, ${3:r} *http.Request) {\n\t$0\n}"
-  'http redirect':
+    'body': "func $1(${2:w} http.ResponseWriter, ${3:r} *http.Request) {\n\t$0\n}"
+  'http.Redirect':
     'prefix': 'rd'
     'body': "http.Redirect(${1:w}, ${2:r}, \"${3:/}\", ${4:http.StatusFound})"
-  'http error':
+  'http.Error':
     'prefix': 'herr'
     'body': "http.Error(${1:w}, ${2:err}.Error(), ${3:http.StatusInternalServerError})"
-  'listenandserve':
+  'http.ListenAndServe':
     'prefix': 'las'
     'body': "http.ListenAndServe(\"${1::8080}\", ${2:nil})"
-  'serve':
+  'http.Serve':
     'prefix': 'sv'
     'body': "http.Serve(\"${1::8080}\", ${2:nil})"
-  'goroutine':
+  'goroutine anonymous function':
     'prefix': 'go'
-    'body': 'go func($1) {\n\t$2\n}($3)'
+    'body': 'go func($1) {\n\t$2\n}($0)'
   'goroutine function':
     'prefix': 'gf'
     'body': 'go ${1:func}($0)'
+  'defer statement':
+    'prefix': 'df'
+    'body': "defer ${1:func}($0)"
   'test function':
     'prefix': 'tf'
     'body': "func Test$1(t *testing.T) {\n\t$0\n}"


### PR DESCRIPTION
None of the prefixes changed except for 1, so all other snippets are still called by the same prefix they currently have.

The `Im` prefix (used for adding a multi import snippet) is changed to `ims`. This seems to make more sense and is easier/faster to type as you no longer have to use the additional `shift` key and `im` is for calling the single import snippet.

So what changed is that mainly the descriptions are updated so they better explain/describe the snippet and the body is (where possible and logical) generalised a bit.