### PR TITLE
Update the scope used for function declarations

### DIFF
--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -62,7 +62,7 @@
           }
         ]
       '4':
-        'name': 'support.function.decl.go'
+        'name': 'entity.name.function'
   }
   {
     'comment': 'Short variable declarations'

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -227,7 +227,7 @@ describe 'Go grammar', ->
       relevantToken = tokens[t.tokenPos]
       expect(relevantToken).toBeDefined()
       expect(relevantToken.value).toEqual 'f'
-      expect(relevantToken.scopes).toEqual ['source.go', 'support.function.decl.go']
+      expect(relevantToken.scopes).toEqual ['source.go', 'entity.name.function']
 
       next = tokens[t.tokenPos + 1]
       expect(next.value).toEqual '('


### PR DESCRIPTION
This makes the `language-go` more inline with the other language packages.

Thanks @Victorystick for pointing this out!