### PR TITLE
Refactor scoping to better match the TextMate guidelines

### DIFF
--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -10,139 +10,217 @@
   {
     'comment': 'Block comments'
     'begin': '/\\*'
+    'end': '\\*/'
     'captures':
       '0':
         'name': 'punctuation.definition.comment.go'
-    'end': '\\*/'
     'name': 'comment.block.go'
   }
   {
     'comment': 'Line comments'
     'begin': '//'
-    'end': '$'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.comment.go'
+    'end': '$'
     'name': 'comment.line.double-slash.go'
   }
   {
-    'comment': 'Syntax error'
-    'match': '\\[\\](\\s+)'
-    'captures':
-      '1':
-        'name': 'invalid.illegal.go'
+    'comment': 'Interpreted string literals'
+    'begin': '"'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.go'
+    'end': '"'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.go'
+    'name': 'string.quoted.double.go'
+    'patterns': [
+      {
+        'include': '#string_escaped_char'
+      }
+      {
+        'include': '#string_placeholder'
+      }
+    ]
   }
   {
-    'comment': 'Syntax error sending channels'
-    'match': '\\bchan([\\t ]+)<\-'
-    'captures':
-      '1':
-        'name': 'invalid.illegal.go'
+    'comment': 'Raw string literals'
+    'begin': '`'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.go'
+    'end': '`'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.go'
+    'name': 'string.quoted.raw.go',
+    'patterns': [
+      {
+        'include': '#string_placeholder'
+      }
+    ]
   }
   {
     'comment': 'Syntax error receiving channels'
     'match': '<\\-([\\t ]+)chan\\b'
     'captures':
       '1':
-        'name': 'invalid.illegal.go'
+        'name': 'invalid.illegal.receive-channel.go'
   }
   {
-    'comment': 'Function declarations'
-    'match': '^(\\bfunc\\b)(\\s+(\\([^\\)]+\\)\\s+)?([\\w_][\\w_\\d]*)(?=\\())?'
+    'comment': 'Syntax error sending channels'
+    'match': '\\bchan([\\t ]+)<\-'
     'captures':
       '1':
-        'name': 'keyword.go'
-      '3':
-        'patterns': [
-          {
-            'include': '#operators'
-          }
-          {
-            'include': '#variables'
-          }
-        ]
-      '4':
-        'name': 'entity.name.function'
+        'name': 'invalid.illegal.send-channel.go'
   }
   {
-    'comment': 'Short variable declarations'
-    'match': '([\\w_][\\w\\d_]*)(?=\\s*:=)'
+    'comment': 'Syntax error using slices'
+    'match': '\\[\\](\\s+)'
     'captures':
       '1':
-        'name': 'variable.go'
+        'name': 'invalid.illegal.slice.go'
+  }
+  {
+    'comment': 'Syntax error numeric literals'
+    'match': '\\b0[0-7]*[89]\\d*\\b'
+    'name': 'invalid.illegal.numeric.go'
   }
   {
     'comment': 'Built-in functions'
     'match': '\\b(append|cap|close|complex|copy|delete|imag|len|make|new|panic|print|println|real|recover)\\b(?=\\()'
+    'name': 'support.function.builtin.go'
+  }
+  {
+    'comment': 'Function declarations'
+    'match': '^(\\bfunc\\b)(?:\\s+(\\([^\\)]+\\)\\s+)?([a-zA-Z_]\\w*)(?=\\())?'
     'captures':
       '1':
-        'name': 'support.function.built-in.go'
+        'name': 'keyword.function.go'
+      '2':
+        'patterns': [
+          {
+            'include': '#brackets'
+          }
+          {
+            'include': '#operators'
+          }
+        ]
+      '3':
+        'name': 'entity.name.function'
   }
   {
     'comment': 'Functions'
-    'match': '(\\bfunc\\b)|([\\w_][\\w\\d_]*)(?=\\()'
+    'match': '(\\bfunc\\b)|([a-zA-Z_]\\w*)(?=\\()'
     'captures':
       '1':
-        'name': 'keyword.go'
+        'name': 'keyword.function.go'
       '2':
         'name': 'support.function.go'
   }
   {
-    'name': 'storage.type.go'
-    'match': '\\b(bool|string|error|int|int8|int16|int32|int64|rune|byte|uint|uint8|uint16|uint32|uint64|uintptr|float32|float64|complex64|complex128)\\b'
+    'comment': 'Floating-point literals'
+    'match': '(\\.\\d+([Ee][\-\+]\\d+)?i?)\\b|\\b\\d+\\.\\d*(([Ee][\-\+]\\d+)?i?\\b)?'
+    'name': 'constant.numeric.floating-point.go'
   }
   {
-    'name': 'invalid.illegal.numeric.go'
-    'match': '\\b0[0-7]*[89]\\d*\\b'
-  }
-  {
-    'name': 'constant.numeric.go'
-    'match': '(\\.\\d+([Ee][\-\+]\\d+)?i?)\\b'
-  }
-  {
-    'name': 'constant.numeric.go'
-    'match': '\\b\\d+\\.\\d*(([Ee][\-\+]\\d+)?i?\\b)?'
-  }
-  {
-    'name': 'constant.numeric.go'
+    'comment': 'Integers'
     'match': '\\b((0x[0-9a-fA-F]+)|(0[0-7]+i?)|(\\d+([Ee]\\d+)?i?)|(\\d+[Ee][\-\+]\\d+i?))\\b'
+    'name': 'constant.numeric.integer.go'
   }
   {
-    'name': 'keyword.go'
-    'match': '\\b(chan|map|func|var|const|type|struct|interface|case|default)\\b'
+    'comment': 'Language constants'
+    'match': '\\b(true|false|nil|iota)\\b'
+    'name': 'constant.language.go'
   }
   {
-    'name': 'keyword.directive.go'
-    'match': '\\b(package|import)\\b'
-  }
-  {
-    'match': '\\bpackage\\b\\s+([\\w_][\\w\\d_]*)'
+    'comment': 'Package declarations'
+    'match': '(?<=package)\\s+([a-zA-Z_]\\w*)'
     'captures':
       '1':
         'name': 'entity.name.package.go'
   }
   {
-    'name': 'keyword.statement.go'
-    'match': '\\b(defer|go|goto|return|break|continue|fallthrough)\\b'
+    'comment': 'Type declarations'
+    'match': '(?<=type)\\s+([a-zA-Z_]\\w*)'
+    'captures':
+      '1':
+        'name': 'entity.name.type.go'
   }
   {
-    'name': 'keyword.conditional.go'
-    'match': '\\b(if|else|switch|select)\\b'
+    'comment': 'Shorthand variable declaration and assignments'
+    'match': '[a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*(?=\\s*:=)'
+    'captures':
+      '0':
+        'patterns': [
+          {
+            'match': '[a-zA-Z_]\\w*'
+            'name': 'variable.other.assignment.go'
+          }
+          {
+            'include': '#delimiters'
+          }
+        ]
   }
   {
-    'name': 'keyword.repeat.go'
-    'match': '\\b(for|range)\\b'
+    'comment': 'Assignments to existing variables'
+    'match': '(?<!var )\\s*([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(?=\\s*=[^=])'
+    'captures':
+      '1':
+        'patterns': [
+          {
+            'match': '[a-zA-Z_]\\w*'
+            'name': 'variable.other.assignment.go'
+          }
+          {
+            'include': '#delimiters'
+          }
+        ]
   }
   {
-    'name': 'constant.language.go'
-    'match': '\\b(iota|true|false|nil)\\b'
+    'comment': 'Single line variable declarations/assignments'
+    'match': '(?<=var)\\s+(.*)$'
+    'captures':
+      '1':
+        'patterns': [
+          {
+            'include': '#variables'
+          }
+        ]
   }
   {
-    'match': '\\;'
-    'name': 'meta.terminator.semicolon.go'
+    'comment': 'Multiline variable declarations/assignments'
+    'begin': '(\\bvar\\b)\\s+(\\()'
+    'beginCaptures':
+      '1':
+        'name': 'keyword.variable.go'
+      '2':
+        'name': 'punctuation.other.bracket.round.go'
+    'end': '\\)'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.other.bracket.round.go'
+    'patterns': [
+      {
+        'include': '#variables'
+      }
+    ]
+  }
+  {
+    'comment': 'Terminators'
+    'match': ';'
+    'name': 'punctuation.terminator.go'
+  }
+  {
+    'include': '#brackets'
   }
   {
     'include': '#delimiters'
+  }
+  {
+    'include': '#keywords'
   }
   {
     'include': '#operators'
@@ -151,122 +229,259 @@
     'include': '#runes'
   }
   {
-    'include': '#strings'
+    'include': '#storage_types'
   }
-  {
-    'include': '#string_escaped_char'
-  }
-  {
-    'include': '#variables'
-  }
-
 ]
 'repository':
+  'brackets':
+    'patterns': [
+      {
+        'match': '\\{|\\}'
+        'name': 'punctuation.other.bracket.curly.go'
+      }
+      {
+        'match': '\\(|\\)'
+        'name': 'punctuation.other.bracket.round.go'
+      }
+      {
+        'match': '\\[|\\]'
+        'name': 'punctuation.other.bracket.square.go'
+      }
+    ]
   'delimiters':
     'patterns': [
       {
         'match': ','
-        'name': 'meta.delimiter.comma.go'
+        'name': 'punctuation.other.comma.go'
       }
       {
         'match': '\\.(?!\\.\\.)'
-        'name': 'meta.delimiter.period.go'
+        'name': 'punctuation.other.period.go'
       }
       {
         'match': ':(?!=)'
-        'name': 'meta.delimiter.colon.go'
+        'name': 'punctuation.other.colon.go'
+      }
+    ]
+  'keywords':
+    'patterns': [
+      {
+        'comment': 'Flow control keywords'
+        'match': '\\b(break|case|continue|default|defer|else|fallthrough|for|go|goto|if|range|return|select|switch)\\b'
+        'name': 'keyword.control.go'
+      }
+      {
+        'match': '\\bchan\\b'
+        'name': 'keyword.channel.go'
+      }
+      {
+        'match': '\\bconst\\b'
+        'name': 'keyword.constant.go'
+      }
+      {
+        'match': '\\bfunc\\b'
+        'name': 'keyword.function.go'
+      }
+      {
+        'match': '\\binterface\\b'
+        'name': 'keyword.interface.go'
+      }
+      {
+        'match': '\\bimport\\b'
+        'name': 'keyword.import.go'
+      }
+      {
+        'match': '\\bmap\\b'
+        'name': 'keyword.map.go'
+      }
+      {
+        'match': '\\bpackage\\b'
+        'name': 'keyword.package.go'
+      }
+      {
+        'match': '\\bstruct\\b'
+        'name': 'keyword.struct.go'
+      }
+      {
+        'match': '\\btype\\b'
+        'name': 'keyword.type.go'
+      }
+      {
+        'match': '\\bvar\\b'
+        'name': 'keyword.variable.go'
       }
     ]
   'operators':
+    'comment': 'Note that the order here is very important!'
     'patterns': [
       {
-        "name": "keyword.operator.go",
-        "match": "(\\+|&|\\+=|&=|&&|==|!=|\\-|\\||\\-=|\\|=|\\|\\||<|<=|\\*|\\^|\\*=|\\^=|<\\-|>|>=|/|<<|/=|<<=|\\+\\+|=|:=|%|>>|%=|>>=|\\-\\-|!|\\.\\.\\.|&\\^|&\\^=)"
+        'match': '(\\*|&)(?=\\w)'
+        'name': 'keyword.operator.address.go'
       }
       {
-        'match': '\\{|\\}'
-        'name': 'meta.brace.curly.go'
+        'match': '<\\-'
+        'name': 'keyword.operator.channel.go'
       }
       {
-        'match': '\\(|\\)'
-        'name': 'meta.brace.round.go'
+        'match': '\\-\\-'
+        'name': 'keyword.operator.decrement.go'
       }
       {
-        'match': '\\[|\\]'
-        'name': 'meta.brace.square.go'
+        'match': '\\+\\+'
+        'name': 'keyword.operator.increment.go'
+      }
+      {
+        'match': '(==|!=|<=|>=|<[^<]|>[^>])'
+        'name': 'keyword.operator.comparison.go'
+      }
+      {
+        'match': '(&&|\\|\\||!)'
+        'name': 'keyword.operator.logical.go'
+      }
+      {
+        'match': '(=|\\+=|\\-=|\\|=|\\^=|\\*=|/=|:=|%=|<<=|>>=|&\\^=|&=)'
+        'name': 'keyword.operator.assignment.go'
+      }
+      {
+        'match': '(\\+|\\-|\\*|/|%)'
+        'name': 'keyword.operator.arithmetic.go'
+      }
+      {
+        'match': '(&(?!\\^)|\\||\\^|&\\^|<<|>>)'
+        'name': 'keyword.operator.arithmetic.bitwise.go'
+      }
+      {
+        'match': '\\.\\.\\.'
+        'name': 'keyword.operator.ellipsis.go'
       }
     ]
   'runes':
     'patterns': [
       {
-        'name': 'constant.other.rune.go'
         'match': '\\\'(\\\\([0-7]{3}|[abfnrtv\\\\\'"]|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8})|\\\p{Any})\\\''
+        'name': 'constant.other.rune.go'
       }
       {
-        'name': 'invalid.illegal.rune.go'
         'match': '\\\'.*\\\''
+        'name': 'invalid.illegal.unknown-rune.go'
       }
     ]
-  'strings':
+  'storage_types':
     'patterns': [
       {
-        'begin': '"'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.string.begin.go'
-        'end': '"'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.string.end.go'
-        'name': 'string.quoted.double.go'
-        'patterns': [
-          {
-            'include': '#string_escaped_char'
-          }
-          {
-            'include': '#string_format_verbs'
-          }
-        ]
+        'match': '\\bbool\\b'
+        'name': 'storage.type.boolean.go'
       }
       {
-        'begin': '`'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.string.begin.go'
-        'end': '`'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.string.end.go'
-        'name': 'string.quoted.raw.go',
-        'patterns': [
-          {
-            'include': '#string_format_verbs'
-          }
-        ]
+        'match': '\\bbyte\\b'
+        'name': 'storage.type.byte.go'
+      }
+      {
+        'match': '\\berror\\b'
+        'name': 'storage.type.error.go'
+      }
+      {
+        'match': '\\b(complex(64|128)|float(32|64)|u?int(8|16|32|64)?)\\b'
+        'name': 'storage.type.numeric.go'
+      }
+      {
+        'match': '\\brune\\b'
+        'name': 'storage.type.rune.go'
+      }
+      {
+        'match': '\\bstring\\b'
+        'name': 'storage.type.string.go'
+      }
+      {
+        'match': '\\buintptr\\b'
+        'name': 'storage.type.uintptr.go'
       }
     ]
   'string_escaped_char':
     'patterns': [
       {
-        'name': 'constant.character.escape.go'
         'match': '\\\\([0-7]{3}|[abfnrtv\\\\\'"]|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8})'
+        'name': 'constant.character.escape.go'
       }
       {
-        'name': 'invalid.illegal.unknown-escape.go'
         'match': '\\\\[^0-7xuUabfnrtv\\\'"]'
+        'name': 'invalid.illegal.unknown-escape.go'
       }
     ]
-  'string_format_verbs':
+  'string_placeholder':
     'patterns': [
       {
-        'name': 'constant.character.escape.go'
         'match': '%(\\[\\d+\\])?([\\+#\\-0\\x20]{,2}((\\d+|\\*)?(\\.?(\\d+|\\*|(\\[\\d+\\])\\*?)?(\\[\\d+\\])?)?))?[vT%tbcdoqxXUbeEfFgGsp]'
+        'name': 'constant.other.placeholder.go'
       }
     ]
   'variables':
+    'comment': 'First add tests and make sure existing tests still pass when changing anything here!'
     'patterns': [
       {
-        'name': 'variable.go'
-        'match': '\\b[\\w_][\\w\\d_]*\\b'
+        'match': '([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)\\s*(=.*)'
+        'captures':
+          '1':
+            'patterns': [
+              {
+                'match': '[a-zA-Z_]\\w*'
+                'name': 'variable.other.assignment.go'
+              }
+              {
+                'include': '#delimiters'
+              }
+            ]
+          '2':
+            'patterns': [
+              {
+                'include': '$self'
+              }
+            ]
+      }
+      {
+        'match': '([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(\\s+[\\*]?[a-zA-Z_]\\w*\\s*)(=.*)'
+        'captures':
+          '1':
+            'patterns': [
+              {
+                'match': '[a-zA-Z_]\\w*'
+                'name': 'variable.other.assignment.go'
+              }
+              {
+                'include': '#delimiters'
+              }
+            ]
+          '2':
+            'patterns': [
+              {
+                'include': '$self'
+              }
+            ]
+          '3':
+            'patterns': [
+              {
+                'include': '$self'
+              }
+            ]
+      }
+      {
+        'match': '([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(\\s+[\\*]?[a-zA-Z_]\\w*\\s*[^=].*)'
+        'captures':
+          '1':
+            'patterns': [
+              {
+                'match': '[a-zA-Z_]\\w*'
+                'name': 'variable.other.declaration.go'
+              }
+              {
+                'include': '#delimiters'
+              }
+            ]
+          '2':
+            'patterns': [
+              {
+                'include': '$self'
+              }
+            ]
       }
     ]

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -41,7 +41,7 @@ describe 'Go grammar', ->
       expect(tokens[2].value).toEqual delim
       expect(tokens[2].scopes).toEqual ['source.go', scope, 'punctuation.definition.string.end.go']
 
-  it 'tokenizes Printf verbs in strings', ->
+  it 'tokenizes placeholders in strings', ->
     # Taken from go/src/pkg/fmt/fmt_test.go
     verbs = [
       '%# x', '%-5s', '%5s', '%05s', '%.5s', '%10.1q', '%10v', '%-10v', '%.0d'
@@ -56,7 +56,7 @@ describe 'Go grammar', ->
       expect(tokens[0].value).toEqual '"',
       expect(tokens[0].scopes).toEqual ['source.go', 'string.quoted.double.go', 'punctuation.definition.string.begin.go']
       expect(tokens[1].value).toEqual verb
-      expect(tokens[1].scopes).toEqual ['source.go', 'string.quoted.double.go', 'constant.character.escape.go']
+      expect(tokens[1].scopes).toEqual ['source.go', 'string.quoted.double.go', 'constant.other.placeholder.go']
       expect(tokens[2].value).toEqual '"',
       expect(tokens[2].scopes).toEqual ['source.go', 'string.quoted.double.go', 'punctuation.definition.string.end.go']
 
@@ -75,7 +75,7 @@ describe 'Go grammar', ->
     expect(tokens[1].value).toEqual '\\"'
     expect(tokens[1].scopes).toEqual ['source.go', 'string.quoted.double.go', 'constant.character.escape.go']
 
-  it 'tokenizes Printf verbs in raw strings', ->
+  it 'tokenizes placeholders in raw strings', ->
     # Taken from go/src/pkg/fmt/fmt_test.go
     verbs = [
       '%# x', '%-5s', '%5s', '%05s', '%.5s', '%10.1q', '%10v', '%-10v', '%.0d'
@@ -90,7 +90,7 @@ describe 'Go grammar', ->
       expect(tokens[0].value).toEqual '`',
       expect(tokens[0].scopes).toEqual ['source.go', 'string.quoted.raw.go', 'punctuation.definition.string.begin.go']
       expect(tokens[1].value).toEqual verb
-      expect(tokens[1].scopes).toEqual ['source.go', 'string.quoted.raw.go', 'constant.character.escape.go']
+      expect(tokens[1].scopes).toEqual ['source.go', 'string.quoted.raw.go', 'constant.other.placeholder.go']
       expect(tokens[2].value).toEqual '`',
       expect(tokens[2].scopes).toEqual ['source.go', 'string.quoted.raw.go', 'punctuation.definition.string.end.go']
 
@@ -106,32 +106,45 @@ describe 'Go grammar', ->
       expect(tokens[0].value).toEqual '\'' + verb + '\'',
       expect(tokens[0].scopes).toEqual ['source.go', 'constant.other.rune.go']
 
-  it 'tokenizes invalid runes and single quote strings', ->
+  it 'tokenizes invalid runes and single quoted strings', ->
     {tokens} = grammar.tokenizeLine('\'ab\'')
     expect(tokens[0].value).toEqual '\'ab\''
-    expect(tokens[0].scopes).toEqual ['source.go', 'invalid.illegal.rune.go']
+    expect(tokens[0].scopes).toEqual ['source.go', 'invalid.illegal.unknown-rune.go']
 
     {tokens} = grammar.tokenizeLine('\'some single quote string\'')
     expect(tokens[0].value).toEqual '\'some single quote string\''
-    expect(tokens[0].scopes).toEqual ['source.go', 'invalid.illegal.rune.go']
+    expect(tokens[0].scopes).toEqual ['source.go', 'invalid.illegal.unknown-rune.go']
 
   it 'tokenizes invalid whitespace around chan annotations', ->
-    invalids =
+    invalid_send =
       'chan <- sendonly': ' '
+
+    invalid_receive =
       '<- chan recvonly': ' '
 
-    for expr, invalid of invalids
+    for expr, invalid of invalid_send
       {tokens} = grammar.tokenizeLine(expr)
       expect(tokens[1].value).toEqual invalid
-      expect(tokens[1].scopes).toEqual ['source.go', 'invalid.illegal.go']
+      expect(tokens[1].scopes).toEqual ['source.go', 'invalid.illegal.send-channel.go']
+
+    for expr, invalid of invalid_receive
+      {tokens} = grammar.tokenizeLine(expr)
+      expect(tokens[1].value).toEqual invalid
+      expect(tokens[1].scopes).toEqual ['source.go', 'invalid.illegal.receive-channel.go']
 
   it 'tokenizes keywords', ->
     keywordLists =
-      'keyword.go': ['func', 'var', 'const', 'type', 'struct', 'interface', 'case', 'default']
-      'keyword.directive.go': ['package', 'import']
-      'keyword.statement.go': ['defer', 'go', 'goto', 'return', 'break', 'continue', 'fallthrough']
-      'keyword.conditional.go': ['if', 'else', 'switch', 'select']
-      'keyword.repeat.go': ['for', 'range']
+      'keyword.control.go': ['break', 'case', 'continue', 'default', 'defer', 'else', 'fallthrough', 'for', 'go', 'goto', 'if', 'range', 'return', 'select', 'switch']
+      'keyword.channel.go': ['chan']
+      'keyword.constant.go': ['const']
+      'keyword.function.go': ['func']
+      'keyword.interface.go': ['interface']
+      'keyword.import.go': ['import']
+      'keyword.map.go': ['map']
+      'keyword.package.go': ['package']
+      'keyword.struct.go': ['struct']
+      'keyword.type.go': ['type']
+      'keyword.variable.go': ['var']
 
     for scope, list of keywordLists
       for keyword in list
@@ -139,24 +152,28 @@ describe 'Go grammar', ->
         expect(tokens[0].value).toEqual keyword
         expect(tokens[0].scopes).toEqual ['source.go', scope]
 
-  it 'tokenizes types', ->
-    types = [
-      'bool',   'string',  'error',   'int',     'int8',      'int16'
-      'int32',  'int64',   'rune',    'byte',    'uint',      'uint8',      'uint16', 'uint32'
-      'uint64', 'uintptr', 'float32', 'float64', 'complex64', 'complex128'
-    ]
+  it 'tokenizes storage types', ->
+    storageTypes =
+      'storage.type.boolean.go': ['bool']
+      'storage.type.byte.go': ['byte']
+      'storage.type.error.go': ['error']
+      'storage.type.numeric.go': ['int', 'int8', 'int16', 'int32', 'int64', 'uint', 'uint8', 'uint16', 'uint32', 'uint64', 'float32', 'float64', 'complex64', 'complex128']
+      'storage.type.rune.go': ['rune']
+      'storage.type.string.go': ['string']
+      'storage.type.uintptr.go': ['uintptr']
 
-    for type in types
-      {tokens} = grammar.tokenizeLine type
-      expect(tokens[0].value).toEqual type
-      expect(tokens[0].scopes).toEqual ['source.go', 'storage.type.go']
+    for scope, types of storageTypes
+      for type in types
+        {tokens} = grammar.tokenizeLine type
+        expect(tokens[0].value).toEqual type
+        expect(tokens[0].scopes).toEqual ['source.go', scope]
 
-  it 'tokenizes "func" as a keyword regardless of the context', ->
+  it 'tokenizes func regardless of the context', ->
     funcKeyword = ['func f()', 'func (x) f()', 'func(x) f()', 'func']
     for line in funcKeyword
       {tokens} = grammar.tokenizeLine line
       expect(tokens[0].value).toEqual 'func'
-      expect(tokens[0].scopes).toEqual ['source.go', 'keyword.go']
+      expect(tokens[0].scopes).toEqual ['source.go', 'keyword.function.go']
 
     funcType = [
       {
@@ -178,51 +195,45 @@ describe 'Go grammar', ->
     ]
     for t in funcType
       {tokens} = grammar.tokenizeLine t.line
-
       relevantToken = tokens[t.tokenPos]
       expect(relevantToken.value).toEqual 'func'
-      expect(relevantToken.scopes).toEqual ['source.go', 'keyword.go']
+      expect(relevantToken.scopes).toEqual ['source.go', 'keyword.function.go']
 
       next = tokens[t.tokenPos + 1]
       expect(next.value).toEqual '('
-      expect(next.scopes).toEqual ['source.go', 'meta.brace.round.go']
+      expect(next.scopes).toEqual ['source.go', 'punctuation.other.bracket.round.go']
 
-  it 'only tokenizes "func" when it is an exact match', ->
+  it 'only tokenizes func when it is an exact match', ->
     tests = ['myfunc', 'funcMap']
     for test in tests
       {tokens} = grammar.tokenizeLine test
       expect(tokens[0].value).not.toEqual 'func'
-      expect(tokens[0].scopes).not.toEqual ['source.go', 'keyword.go']
+      expect(tokens[0].scopes).not.toEqual ['source.go', 'keyword.function.go']
 
   it 'tokenizes func names in their declarations', ->
     tests = [
-      # {
-      #   'line': 'func f()'
-      #   'tokenPos': 2
-      # }
+      {
+        'line': 'func f()'
+        'tokenPos': 2
+      }
       {
         'line': 'func (T) f()'
         'tokenPos': 6
       }
-      # {
-      #   'line': 'func (t T) f()'
-      #   'tokenPos': 8
-      # }
-      # {
-      #   'line': 'func (t *T) f()'
-      #   'tokenPos': 9
-      # }
+      {
+        'line': 'func (t T) f()'
+        'tokenPos': 6
+      }
+      {
+        'line': 'func (t *T) f()'
+        'tokenPos': 8
+      }
     ]
 
     for t in tests
       {tokens} = grammar.tokenizeLine t.line
       expect(tokens[0].value).toEqual 'func'
-      expect(tokens[0].scopes).toEqual ['source.go', 'keyword.go']
-      expect(tokens[1].value).toEqual ' '
-      expect(tokens[2].value).toEqual '('
-      expect(tokens[3].value).toEqual 'T'
-      expect(tokens[4].value).toEqual ')'
-      expect(tokens[5].value).toEqual ' '
+      expect(tokens[0].scopes).toEqual ['source.go', 'keyword.function.go']
 
       relevantToken = tokens[t.tokenPos]
       expect(relevantToken).toBeDefined()
@@ -231,49 +242,38 @@ describe 'Go grammar', ->
 
       next = tokens[t.tokenPos + 1]
       expect(next.value).toEqual '('
-      expect(next.scopes).toEqual ['source.go', 'meta.brace.round.go']
+      expect(next.scopes).toEqual ['source.go', 'punctuation.other.bracket.round.go']
 
-  it 'tokenizes receiver types in method declarations', ->
+  it 'tokenizes operators method declarations', ->
     tests = [
       {
-        'line': 'func (T) f()'
-        'tokenPos': 3
-      }
-      {
-        'line': 'func (t T) f()'
-        'tokenPos': 5
-      }
-      {
         'line': 'func (t *T) f()'
-        'tokenPos': 6
+        'tokenPos': 4
       }
     ]
 
     for t in tests
       {tokens} = grammar.tokenizeLine t.line
       expect(tokens[0].value).toEqual 'func'
-      expect(tokens[0].scopes).toEqual ['source.go', 'keyword.go']
+      expect(tokens[0].scopes).toEqual ['source.go', 'keyword.function.go']
 
       relevantToken = tokens[t.tokenPos]
-      expect(relevantToken).toBeDefined()
-      expect(relevantToken.value).toEqual 'T'
-      expect(relevantToken.scopes).toEqual ['source.go', 'variable.go']
-
-      next = tokens[t.tokenPos + 1]
-      expect(next.value).toEqual ')'
-      expect(next.scopes).toEqual ['source.go', 'meta.brace.round.go']
+      expect(relevantToken.value).toEqual '*'
+      expect(relevantToken.scopes).toEqual ['source.go', 'keyword.operator.address.go']
 
   it 'tokenizes numerics', ->
-    numerics = [
-      '42', '0600', '0xBadFace', '170141183460469231731687303715884105727', '0.', '72.40'
-      '072.40', '2.71828', '1.e+0', '6.67428e-11', '1E6', '.25', '.12345E+5', '0i', '011i'
-      '0.i', '2.71828i', '1.e+0i', '6.67428e-11i', '1E6i', '.25i', '.12345E+5i'
-    ]
+    numbers =
+      'constant.numeric.integer.go': ['42', '0600', '0xBadFace', '170141183460469231731687303715884105727', '1E6', '0i', '011i', '1E6i']
+      'constant.numeric.floating-point.go': [
+        '0.', '72.40', '072.40', '2.71828', '1.e+0', '6.67428e-11', '.25', '.12345E+5',
+        '0.i', '2.71828i', '1.e+0i', '6.67428e-11i', '.25i', '.12345E+5i'
+      ]
 
-    for num in numerics
-      {tokens} = grammar.tokenizeLine num
-      expect(tokens[0].value).toEqual num
-      expect(tokens[0].scopes).toEqual ['source.go', 'constant.numeric.go']
+    for scope, nums of numbers
+      for num in nums
+        {tokens} = grammar.tokenizeLine num
+        expect(tokens[0].value).toEqual num
+        expect(tokens[0].scopes).toEqual ['source.go', scope]
 
     invalidOctals = ['08', '039', '0995']
     for num in invalidOctals
@@ -282,7 +282,7 @@ describe 'Go grammar', ->
       expect(tokens[0].scopes).toEqual ['source.go', 'invalid.illegal.numeric.go']
 
   it 'tokenizes language constants', ->
-    constants = ['iota', 'true', 'false', 'nil']
+    constants = ['true', 'false', 'nil', 'iota']
     for constant in constants
       {tokens} = grammar.tokenizeLine constant
       expect(tokens[0].value).toEqual constant
@@ -299,81 +299,60 @@ describe 'Go grammar', ->
       funcVal = funcVals[funcs.indexOf(func)]
       {tokens} = grammar.tokenizeLine func
       expect(tokens[0].value).toEqual funcVal
-      expect(tokens[0].scopes).toEqual ['source.go', 'support.function.built-in.go']
+      expect(tokens[0].scopes).toEqual ['source.go', 'support.function.builtin.go']
 
   it 'tokenizes operators', ->
-    opers = [
-      '+', '&', '+=', '&=', '&&', '==', '!=', '-', '|', '-=', '|=', '||', '<',
-      '<=', '*', '^', '*=', '^=', '<-', '>', '>=', '/', '<<', '/=',
-      '<<=', '++', '=', ':=', '%', '>>', '%=', '>>=', '--', '!', '...',
-      '&^', '&^='
-    ]
+    binaryOpers =
+      'keyword.operator.arithmetic.go': ['+', '-', '*', '/', '%']
+      'keyword.operator.arithmetic.bitwise.go': ['&', '|', '^', '&^', '<<', '>>']
+      'keyword.operator.assignment.go': ['=', '+=', '-=', '|=', '^=', '*=', '/=', ':=', '%=', '<<=', '>>=', '&=', '&^=']
+      'keyword.operator.channel.go': ['<-']
+      'keyword.operator.comparison.go': ['==', '!=', '<', '<=', '>', '>=']
+      'keyword.operator.decrement.go': ['--']
+      'keyword.operator.ellipsis.go': ['...']
+      'keyword.operator.increment.go': ['++']
+      'keyword.operator.logical.go': ['&&', '||']
 
-    for op in opers
-      {tokens} = grammar.tokenizeLine op
+    unaryOpers =
+      'keyword.operator.address.go': ['*var', '&var']
+      'keyword.operator.arithmetic.go': ['+var', '-var']
+      'keyword.operator.arithmetic.bitwise.go': ['^var']
+      'keyword.operator.logical.go': ['!var']
 
-      fullOp = tokens.map((tok) -> tok.value).join('')
-      expect(fullOp).toEqual op
-
-      scopes = tokens.map (tok) -> tok.scopes
-      allKeywords = scopes.every (scope) -> 'keyword.operator.go' in scope
-
-      expect(allKeywords).toBe true
-
-  it 'tokenizes bracket operators', ->
-    opers = [
-      {
-        values: [ '[', ']' ]
-        scope: 'meta.brace.square.go'
-      }
-      {
-        values: [ '(', ')' ]
-        scope: 'meta.brace.round.go'
-      }
-      {
-        values: [ '{', '}' ]
-        scope: 'meta.brace.curly.go'
-      }
-    ]
-
-    for ops in opers
+    for scope, ops of binaryOpers
       for op in ops
         {tokens} = grammar.tokenizeLine op
+        expect(tokens[0].value).toEqual op
+        expect(tokens[0].scopes).toEqual ['source.go', scope]
 
-        fullOp = tokens.map((tok) -> tok.value).join('')
-        expect(fullOp).toEqual op
+    for scope, ops of unaryOpers
+      for op in ops
+        {tokens} = grammar.tokenizeLine op
+        expect(tokens[0].value).toEqual op[0]
+        expect(tokens[0].scopes).toEqual ['source.go', scope]
 
-        scopes = tokens.map (tok) -> tok.scopes
-        allKeywords = scopes.every (scope) -> ops.scope in scope
+  it 'tokenizes punctuation brackets', ->
+    brackets =
+      'punctuation.other.bracket.square.go': [ '[', ']' ]
+      'punctuation.other.bracket.round.go': [ '(', ')' ]
+      'punctuation.other.bracket.curly.go': [ '{', '}' ]
 
-        expect(allKeywords).toBe true
+    for scope, brkts of brackets
+      for brkt in brkts
+        {tokens} = grammar.tokenizeLine brkt
+        expect(tokens[0].value).toEqual brkt
+        expect(tokens[0].scopes).toEqual ['source.go', scope]
 
-  it 'tokenizes punctuation operators', ->
-    opers = [
-      {
-        value: ','
-        scope: 'meta.delimiter.comma.go'
-      }
-      {
-        value: '.'
-        scope: 'meta.delimiter.period.go'
-      }
-      {
-        value: ':'
-        scope: 'meta.delimiter.colon.go'
-      }
-    ]
+  it 'tokenizes punctuation delimiters', ->
+    delims =
+      'punctuation.other.comma.go': ','
+      'punctuation.other.period.go': '.'
+      'punctuation.other.colon.go': ':'
 
-    for op in opers
-      {tokens} = grammar.tokenizeLine op.value
-
-      fullOp = tokens.map((tok) -> tok.value).join('')
-      expect(fullOp).toEqual op.value
-
-      scopes = tokens.map (tok) -> tok.scopes
-      allKeywords = scopes.every (scope) -> op.scope in scope
-
-      expect(allKeywords).toBe true
+    for scope, delim of delims
+      {tokens} = grammar.tokenizeLine delim
+      expect(tokens[0].value).toEqual delim
+      expect(tokens[0].scopes).toEqual ['source.go', scope]
 
   it 'tokenizes func names in calls to them', ->
     tests = [
@@ -428,82 +407,126 @@ describe 'Go grammar', ->
 
         next = tokens[t.tokenPos + 1]
         expect(next.value).toEqual '('
-        expect(next.scopes).toEqual ['source.go', 'meta.brace.round.go']
+        expect(next.scopes).toEqual ['source.go', 'punctuation.other.bracket.round.go']
       else
         expect(relevantToken.scopes).not.toEqual want
+
+  it 'tokenizes package names', ->
+    tests = ['package main', 'package mypackage']
+
+    for test in tests
+      {tokens} = grammar.tokenizeLine test
+      expect(tokens[0].scopes).toEqual ['source.go', 'keyword.package.go']
+      expect(tokens[2].scopes).toEqual ['source.go', 'entity.name.package.go']
+
+  it 'tokenizes type names', ->
+    tests = ['type mystring string', 'type mytype interface{']
+
+    for test in tests
+      {tokens} = grammar.tokenizeLine test
+      expect(tokens[0].scopes).toEqual ['source.go', 'keyword.type.go']
+      expect(tokens[2].scopes).toEqual ['source.go', 'entity.name.type.go']
 
   describe 'in variable declarations', ->
     testVar = (token) ->
       expect(token.value).toBe 'var'
-      expect(token.scopes).toEqual ['source.go', 'keyword.go']
+      expect(token.scopes).toEqual ['source.go', 'keyword.variable.go']
 
-    plainScope = ['source.go', 'variable.go']
-
-    testName = (token, name) ->
+    testVarAssignment = (token, name) ->
       expect(token.value).toBe name
-      expect(token.scopes).toEqual plainScope
+      expect(token.scopes).toEqual ['source.go', 'variable.other.assignment.go']
+
+    testVarDeclaration = (token, name) ->
+      expect(token.value).toBe name
+      expect(token.scopes).toEqual ['source.go', 'variable.other.declaration.go']
 
     testOp = (token, op) ->
       expect(token.value).toBe op
       expect(token.scopes).toEqual ['source.go', 'keyword.operator.go']
 
+    testOpAddress = (token, op) ->
+      expect(token.value).toBe op
+      expect(token.scopes).toEqual ['source.go', 'keyword.operator.address.go']
+
+    testOpAssignment = (token, op) ->
+      expect(token.value).toBe op
+      expect(token.scopes).toEqual ['source.go', 'keyword.operator.assignment.go']
+
     testOpBracket = (token, op) ->
       expect(token.value).toBe op
-      expect(token.scopes).toEqual ['source.go', 'meta.brace.round.go']
+      expect(token.scopes).toEqual ['source.go', 'punctuation.other.bracket.round.go']
 
     testOpPunctuation = (token, op) ->
       expect(token.value).toBe op
-      expect(token.scopes).toEqual ['source.go', 'meta.delimiter.comma.go']
+      expect(token.scopes).toEqual ['source.go', 'punctuation.other.comma.go']
+
+    testOpTermination = (token, op) ->
+      expect(token.value).toBe op
+      expect(token.scopes).toEqual ['source.go', 'punctuation.terminator.go']
 
     testType = (token, name) ->
       expect(token.value).toBe name
-      expect(token.scopes).toEqual ['source.go', 'storage.type.go']
+      expect(token.scopes).toEqual ['source.go', 'storage.type.numeric.go']
 
     testNum = (token, value) ->
       expect(token.value).toBe value
-      expect(token.scopes).toEqual ['source.go', 'constant.numeric.go']
+      expect(token.scopes).toEqual ['source.go', 'constant.numeric.integer.go']
 
-    describe 'in "var" statements', ->
+    describe 'in var statements', ->
+      it 'tokenizes a single variable assignment', ->
+        {tokens} = grammar.tokenizeLine 'i = 7'
+        testVarAssignment tokens[0], 'i'
+        testOpAssignment tokens[2], '='
+        testNum tokens[4], '7'
+
+      it 'tokenizes a multiple variable assignments', ->
+        {tokens} = grammar.tokenizeLine 'i, j = 7, 8'
+        testVarAssignment tokens[0], 'i'
+        testOpPunctuation tokens[1], ','
+        testVarAssignment tokens[3], 'j'
+        testOpAssignment tokens[5], '='
+        testNum tokens[7], '7'
+        testNum tokens[10], '8'
+
       it 'tokenizes a single name and a type', ->
         {tokens} = grammar.tokenizeLine 'var i int'
         testVar tokens[0]
-        testName tokens[2], 'i'
+        testVarDeclaration tokens[2], 'i'
         testType tokens[4], 'int'
 
       it 'tokenizes a single name and its initialization', ->
         {tokens} = grammar.tokenizeLine ' var k =  0'
         testVar tokens[1]
-        testName tokens[3], 'k'
-        testOp tokens[5], '='
+        testVarAssignment tokens[3], 'k'
+        testOpAssignment tokens[5], '='
         testNum tokens[7], '0'
 
       it 'tokenizes a single name, a type, and an initialization', ->
         {tokens} = grammar.tokenizeLine 'var z blub = 7'
         testVar tokens[0]
-        testName tokens[2], 'z'
-        testName tokens[4], 'blub'
-        testOp tokens[6], '='
-        testNum tokens[8], '7'
+        testVarAssignment tokens[2], 'z'
+        expect(tokens[3].scopes).toEqual ['source.go']
+        testOpAssignment tokens[4], '='
+        testNum tokens[6], '7'
 
       it 'tokenizes multiple names and a type', ->
         {tokens} = grammar.tokenizeLine 'var U, V,  W  float64'
         testVar tokens[0]
-        testName tokens[2], 'U'
+        testVarDeclaration tokens[2], 'U'
         testOpPunctuation tokens[3], ','
-        testName tokens[5], 'V'
+        testVarDeclaration tokens[5], 'V'
         testOpPunctuation tokens[6], ','
-        testName tokens[8], 'W'
-        testType tokens[10], 'float64'
+        testVarDeclaration tokens[8], 'W'
 
       it 'tokenizes multiple names and initialization expressions', ->
         {tokens} = grammar.tokenizeLine 'var x, y, z = 1, 2, 3'
         testVar tokens[0]
-        testName tokens[2], 'x'
+        testVarAssignment tokens[2], 'x'
         testOpPunctuation tokens[3], ','
-        testName tokens[5], 'y'
+        testVarAssignment tokens[5], 'y'
         testOpPunctuation tokens[6], ','
-        testName tokens[8], 'z'
-        testOp tokens[10], '='
+        testVarAssignment tokens[8], 'z'
+        testOpAssignment tokens[10], '='
         testNum tokens[12], '1'
         testOpPunctuation tokens[13], ','
         testNum tokens[15], '2'
@@ -513,45 +536,42 @@ describe 'Go grammar', ->
       it 'tokenizes multiple names, a type, and initialization expressions', ->
         {tokens} = grammar.tokenizeLine 'var x, y float32 = float, thirtytwo'
         testVar tokens[0]
-        testName tokens[2], 'x'
+        testVarAssignment tokens[2], 'x'
         testOpPunctuation tokens[3], ','
-        testName tokens[5], 'y'
+        testVarAssignment tokens[5], 'y'
         testType tokens[7], 'float32'
-        testOp tokens[9], '='
-        testName tokens[11], 'float'
-        testOpPunctuation tokens[12], ','
-        testName tokens[14], 'thirtytwo'
+        testOpAssignment tokens[9], '='
+        testOpPunctuation tokens[11], ','
 
       it 'tokenizes multiple names and a function call', ->
         {tokens} = grammar.tokenizeLine 'var re, im = complexSqrt(-1)'
         testVar tokens[0]
-        testName tokens[2], 're'
-        testName tokens[5], 'im'
-        testOp tokens[7], '='
+        testVarAssignment tokens[2], 're'
+        testVarAssignment tokens[5], 'im'
+        testOpAssignment tokens[7], '='
 
       it 'tokenizes with a placeholder', ->
         {tokens} = grammar.tokenizeLine 'var _, found = entries[name]'
         testVar tokens[0]
-        testName tokens[2], '_'
-        testName tokens[5], 'found'
-        testOp tokens[7], '='
+        testVarAssignment tokens[2], '_'
+        testVarAssignment tokens[5], 'found'
+        testOpAssignment tokens[7], '='
 
-      describe 'in "var" statement blocks', ->
+      describe 'in var statement blocks', ->
         it 'tokenizes single names with a type', ->
           [kwd, decl, closing] = grammar.tokenizeLines '\tvar (\n\t\tfoo *bar\n\t)'
           testVar kwd[1]
           testOpBracket kwd[3], '('
-          testName decl[1], 'foo'
-          testOp decl[3], '*'
-          testName decl[4], 'bar'
+          testVarDeclaration decl[1], 'foo'
+          testOpAddress decl[3], '*'
           testOpBracket closing[1], ')'
 
         it 'tokenizes single names with an initializer', ->
           [kwd, decl, closing] = grammar.tokenizeLines 'var (\n\tfoo = 42\n)'
           testVar kwd[0], 'var'
           testOpBracket kwd[2], '('
-          testName decl[1], 'foo'
-          testOp decl[3], '='
+          testVarAssignment decl[1], 'foo'
+          testOpAssignment decl[3], '='
           testNum decl[5], '42'
           testOpBracket closing[0], ')'
 
@@ -559,33 +579,32 @@ describe 'Go grammar', ->
           [kwd, _, decl, closing] = grammar.tokenizeLines 'var (\n\n\tfoo, bar = baz, quux\n)'
           testVar kwd[0]
           testOpBracket kwd[2], '('
-          testName decl[1], 'foo'
+          testVarAssignment decl[1], 'foo'
           testOpPunctuation decl[2], ','
-          testName decl[4], 'bar'
-          testOp decl[6], '='
-          testName decl[8], 'baz'
-          testOpPunctuation decl[9], ','
-          testName decl[11], 'quux'
+          testVarAssignment decl[4], 'bar'
+          testOpAssignment decl[6], '='
+          testOpPunctuation decl[8], ','
           testOpBracket closing[0], ')'
 
       describe 'in shorthand variable declarations', ->
         it 'tokenizes single names', ->
           {tokens} = grammar.tokenizeLine 'f := func() int { return 7 }'
-          testName tokens[0], 'f'
-          testOp tokens[2], ':='
+          testVarAssignment tokens[0], 'f'
+          testOpAssignment tokens[2], ':='
 
           {tokens} = grammar.tokenizeLine 'ch := make(chan int)'
-          testName tokens[0], 'ch'
-          testOp tokens[2], ':='
+          testVarAssignment tokens[0], 'ch'
+          testOpAssignment tokens[2], ':='
 
-        xit 'tokenizes multiple names', ->
+        it 'tokenizes multiple names', ->
           {tokens} = grammar.tokenizeLine 'i, j := 0, 10'
-          testName tokens[0], 'i'
+          testVarAssignment tokens[0], 'i'
           testOpPunctuation tokens[1], ','
-          testName tokens[3], 'j'
+          testVarAssignment tokens[3], 'j'
 
           {tokens} = grammar.tokenizeLine 'if _, y, z := coord(p); z > 0'
-          testName tokens[2], '_'
-          testName tokens[5], 'y'
-          testName tokens[8], 'z'
-          testOp tokens[10], ':='
+          testVarAssignment tokens[2], '_'
+          testVarAssignment tokens[5], 'y'
+          testVarAssignment tokens[8], 'z'
+          testOpAssignment tokens[10], ':='
+          testOpTermination tokens[16], ';'


### PR DESCRIPTION
- Improve scope names used
- Improve regexps to better match according to the language specs
- Prevent that everything that is not matched, is matched as a variable
- Update and fix existing tests (some turned out to be broken even before I started with this refactor, causing them to always return success while they actually failed)
- Add more tests

Even through functions are still scoped as `keyword.function.go` and not as `storage.type.function.go`, this PR still fixes issue #62 IMO. I've looked again and again at the language specs and also at other existing syntax highlighting packages for Go, and they all (Sublime, Emacs, Vim) seem to threat these (`chan`, `const`, `func`, `interface`, `map`, `struct`, `type` and `var`) as `keywords` instead of `support.types` that are used for these in most other languages.

So I think and believe that most (if not all) Go developers would feel alienated if we changed that for Atom. And to do that only because it seems to be closer to the TextMate guidelines feels a little weird. Next to it being questionable when looking at the language specs. So in the end I decided to keep these specific ones as `keywords` which should give Go developers the experience they expect and are used to.