### PR TITLE
Fix scopes for variables and constants so they are highlighted correctly

### DIFF
--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -195,7 +195,7 @@
     'begin': '(\\bvar\\b)\\s+(\\()'
     'beginCaptures':
       '1':
-        'name': 'keyword.variable.go'
+        'name': 'keyword.var.go'
       '2':
         'name': 'punctuation.other.bracket.round.go'
     'end': '\\)'
@@ -276,7 +276,7 @@
       }
       {
         'match': '\\bconst\\b'
-        'name': 'keyword.constant.go'
+        'name': 'keyword.const.go'
       }
       {
         'match': '\\bfunc\\b'
@@ -308,7 +308,7 @@
       }
       {
         'match': '\\bvar\\b'
-        'name': 'keyword.variable.go'
+        'name': 'keyword.var.go'
       }
     ]
   'operators':

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -136,7 +136,7 @@ describe 'Go grammar', ->
     keywordLists =
       'keyword.control.go': ['break', 'case', 'continue', 'default', 'defer', 'else', 'fallthrough', 'for', 'go', 'goto', 'if', 'range', 'return', 'select', 'switch']
       'keyword.channel.go': ['chan']
-      'keyword.constant.go': ['const']
+      'keyword.const.go': ['const']
       'keyword.function.go': ['func']
       'keyword.interface.go': ['interface']
       'keyword.import.go': ['import']
@@ -144,7 +144,7 @@ describe 'Go grammar', ->
       'keyword.package.go': ['package']
       'keyword.struct.go': ['struct']
       'keyword.type.go': ['type']
-      'keyword.variable.go': ['var']
+      'keyword.var.go': ['var']
 
     for scope, list of keywordLists
       for keyword in list
@@ -430,7 +430,7 @@ describe 'Go grammar', ->
   describe 'in variable declarations', ->
     testVar = (token) ->
       expect(token.value).toBe 'var'
-      expect(token.scopes).toEqual ['source.go', 'keyword.variable.go']
+      expect(token.scopes).toEqual ['source.go', 'keyword.var.go']
 
     testVarAssignment = (token, name) ->
       expect(token.value).toBe name


### PR DESCRIPTION
This fixes unexpected highlighting where .variable and/or .constant are used in themes for specific highlights.