### PR TITLE
decreaseNextIndentPattern: prevent catastrophic backtracking

### DIFF
--- a/settings/language-go.cson
+++ b/settings/language-go.cson
@@ -3,4 +3,4 @@
     'commentStart': '// '
     'increaseIndentPattern': '^.*(\\bcase\\b.*:|\\bdefault\\b:|(\\b(func|if|else|switch|select|for|struct)\\b.*|\\w)\\{[^}]*|\\([^)]*)$'
     'decreaseIndentPattern': '^\\s*(\\bcase\\b.*:|\\bdefault\\b:|\\}[),]?|\\)[,]?)$'
-    'decreaseNextIndentPattern': '^\\s*[^\\s()}]+(?<m>[^()]*\\((?:\\g<m>|[^()]*)\\)[^()]*)*[^()]*\\)[,]?$'
+    'decreaseNextIndentPattern': '^\\s*[^\\s()}]+(?<m>[^()]*\\((?:\\g<m>[^()]*|[^()]*)\\))*[^()]*\\)[,]?$'

--- a/spec/language-go-spec.coffee
+++ b/spec/language-go-spec.coffee
@@ -46,7 +46,14 @@ describe 'Go settings', ->
 
     expect(decreaseNextIndentRegex.testSync('  fmt.Println("something"))')).toBeTruthy()
     expect(decreaseNextIndentRegex.testSync('  fmt.Println("something")),')).toBeTruthy()
+    expect(decreaseNextIndentRegex.testSync('  fmt.Println("something"), "x"),')).toBeTruthy()
     expect(decreaseNextIndentRegex.testSync('  fmt.Println(fmt.Sprint("something"))),')).toBeTruthy()
+    expect(decreaseNextIndentRegex.testSync('  fmt.Println(fmt.Sprint("something"), "x")),')).toBeTruthy()
 
     expect(decreaseNextIndentRegex.testSync('  fmt.Println("something")')).toBeFalsy()
     expect(decreaseNextIndentRegex.testSync('  fmt.Println("something"),')).toBeFalsy()
+
+    # a line with many (), testing for catastrophic backtracking.
+    # see https://github.com/atom/language-go/issues/78
+    longLine = 'first.second().third().fourth().fifth().sixth().seventh().eighth().ninth().tenth()'
+    expect(decreaseNextIndentRegex.testSync(longLine)).toBeFalsy()


### PR DESCRIPTION
The capturing group m: `(?<m>[^()]*\\((?:\\g<m>|[^()]*)\\)[^()]*)`
is prone to catastrophic backtracking because the two [^()]* outside the
parentheses literals can both match each link in a chain a()b()c()d()...
Moving the latter [^()]* inside the parentheses has the same matching
behavior as the original regex and won't catastrophically backtrack.

Fixes https://github.com/atom/language-go/issues/78 and https://github.com/atom/atom/issues/10272.