### PR TITLE
Add Snippet to handle Context, ResponseWriter, *http.Request handlers

### DIFF
--- a/snippets/language-go.cson
+++ b/snippets/language-go.cson
@@ -89,6 +89,9 @@
   'http ResponseWriter *Request':
     'prefix': 'wr'
     'body': "${1:w} http.ResponseWriter, ${2:r} *http.Request"
+  'http Context ResponseWriter *Request':
+    'prefix': 'cwr'
+    'body': "${1:c} context.Context, ${2:w} http.ResponseWriter, ${3:r} *http.Request"
   'http.HandleFunc':
     'prefix': 'hf'
     'body': "${1:http}.HandleFunc(\"${2:/}\", ${3:handler})"


### PR DESCRIPTION
This adds a snippet for quickly writing context-aware http Handlers.
Depends on: golang.org/x/net/context