### PR TITLE
Add Scope For Alias and Package Name of Import Declarations

### DIFF
--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -143,6 +143,36 @@
         'name': 'entity.name.package.go'
   }
   {
+    'comment': 'Single line import declarations'
+    'match': '(?<=import)\\s+([^\\s]*)?\\s?"([^"]*)"'
+    'captures':
+      '1':
+        'name': 'entity.alias.import.go'
+      '2':
+        'name': 'entity.name.import.go'
+  }
+  {
+    'comment': 'Multiline import declarations'
+    'begin': '(?<=import)\\s+(\\()'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.other.bracket.round.go'
+    'patterns': [
+      {
+        'match': '((?!\\s+")[^\\s]*)?\\s+"([^"]*)"'
+        'captures':
+          '1':
+            'name': 'entity.alias.import.go'
+          '2':
+            'name': 'entity.name.import.go'
+      }
+    ]
+    'end': '\\)'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.other.bracket.round.go'
+  }
+  {
     'comment': 'Type declarations'
     'match': '(?<=type)\\s+([a-zA-Z_]\\w*)'
     'captures':

--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -144,12 +144,18 @@
   }
   {
     'comment': 'Single line import declarations'
-    'match': '(?<=import)\\s+([^\\s]*)?\\s?"([^"]*)"'
+    'match': '(?<=import)\\s+([^\\s]*)?\\s?((")([^"]*)("))'
     'captures':
       '1':
         'name': 'entity.alias.import.go'
       '2':
+        'name': 'string.quoted.double.go'
+      '3':
+        'name': 'punctuation.definition.string.begin.go'
+      '4':
         'name': 'entity.name.import.go'
+      '5':
+        'name': 'punctuation.definition.string.end.go'
   }
   {
     'comment': 'Multiline import declarations'
@@ -159,12 +165,18 @@
         'name': 'punctuation.other.bracket.round.go'
     'patterns': [
       {
-        'match': '((?!\\s+")[^\\s]*)?\\s+"([^"]*)"'
+        'match': '((?!\\s+")[^\\s]*)?\\s+((")([^"]*)("))'
         'captures':
           '1':
             'name': 'entity.alias.import.go'
           '2':
+            'name': 'string.quoted.double.go'
+          '3':
+            'name': 'punctuation.definition.string.begin.go'
+          '4':
             'name': 'entity.name.import.go'
+          '5':
+            'name': 'punctuation.definition.string.end.go'
       }
     ]
     'end': '\\)'

--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -144,17 +144,17 @@
   }
   {
     'comment': 'Single line import declarations'
-    'match': '(?<=import)\\s+([^\\s]*)?\\s?((")([^"]*)("))'
+    'match': '(?<=import)(\\s+((?!\\s+")[^\\s]*)?\\s*)((")([^"]*)("))'
     'captures':
-      '1':
-        'name': 'entity.alias.import.go'
       '2':
-        'name': 'string.quoted.double.go'
+        'name': 'entity.alias.import.go'
       '3':
-        'name': 'punctuation.definition.string.begin.go'
+        'name': 'string.quoted.double.go'
       '4':
-        'name': 'entity.name.import.go'
+        'name': 'punctuation.definition.string.begin.go'
       '5':
+        'name': 'entity.name.import.go'
+      '6':
         'name': 'punctuation.definition.string.end.go'
   }
   {

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -656,42 +656,62 @@ describe 'Go grammar', ->
 
     testImportPackage = (token, name) ->
       expect(token.value).toBe name
-      expect(token.scopes).toEqual ['source.go', 'entity.name.import.go']
+      expect(token.scopes).toEqual ['source.go', 'string.quoted.double.go', 'entity.name.import.go']
 
     testOpBracket = (token, op) ->
       expect(token.value).toBe op
       expect(token.scopes).toEqual ['source.go', 'punctuation.other.bracket.round.go']
 
+    testBeginQuoted = (token) ->
+      expect(token.value).toBe '"'
+      expect(token.scopes).toEqual ['source.go', 'string.quoted.double.go', 'punctuation.definition.string.begin.go']
+
+    testEndQuoted = (token) ->
+      expect(token.value).toBe '"'
+      expect(token.scopes).toEqual ['source.go', 'string.quoted.double.go', 'punctuation.definition.string.end.go']
+
     describe 'when it is a single line declaration', ->
       it 'tokenizes declarations with a package name', ->
         {tokens} = grammar.tokenizeLine 'import "fmt"'
         testImport tokens[0]
-        testImportPackage tokens[2], 'fmt'
+        testBeginQuoted tokens[2]
+        testImportPackage tokens[3], 'fmt'
+        testEndQuoted tokens[4]
 
       it 'tokenizes declarations with a package name and an alias', ->
         {tokens} = grammar.tokenizeLine 'import . "fmt"'
         testImport tokens[0]
         testImportAlias tokens[2], '.'
-        testImportPackage tokens[4], 'fmt'
+        testBeginQuoted tokens[4]
+        testImportPackage tokens[5], 'fmt'
+        testEndQuoted tokens[6]
         {tokens} = grammar.tokenizeLine 'import otherpackage "github.com/test/package"'
         testImport tokens[0]
         testImportAlias tokens[2], 'otherpackage'
-        testImportPackage tokens[4], 'github.com/test/package'
+        testBeginQuoted tokens[4]
+        testImportPackage tokens[5], 'github.com/test/package'
+        testEndQuoted tokens[6]
 
     describe 'when it is a multi line declaration', ->
       it 'tokenizes single declarations with a package name', ->
         [kwd, decl, closing] = grammar.tokenizeLines 'import (\n\t"github.com/test/package"\n)'
         testImport kwd[0]
         testOpBracket kwd[2], '('
-        testImportPackage decl[1], 'github.com/test/package'
+        testBeginQuoted decl[1]
+        testImportPackage decl[2], 'github.com/test/package'
+        testEndQuoted decl[3]
         testOpBracket closing[0], ')'
 
       it 'tokenizes multiple declarations with a package name', ->
         [kwd, decl, decl2, closing] = grammar.tokenizeLines 'import (\n\t"github.com/test/package"\n\t"fmt"\n)'
         testImport kwd[0]
         testOpBracket kwd[2], '('
-        testImportPackage decl[1], 'github.com/test/package'
-        testImportPackage decl2[1], 'fmt'
+        testBeginQuoted decl[1]
+        testImportPackage decl[2], 'github.com/test/package'
+        testEndQuoted decl[3]
+        testBeginQuoted decl2[1]
+        testImportPackage decl2[2], 'fmt'
+        testEndQuoted decl2[3]
         testOpBracket closing[0], ')'
 
       it 'tokenizes single imports with an alias for a multi-line declaration', ->
@@ -699,7 +719,9 @@ describe 'Go grammar', ->
         testImport kwd[0]
         testOpBracket kwd[2], '('
         testImportAlias decl[1], '.'
-        testImportPackage decl[3], 'github.com/test/package'
+        testBeginQuoted decl[3]
+        testImportPackage decl[4], 'github.com/test/package'
+        testEndQuoted decl[5]
         testOpBracket closing[0], ')'
 
       it 'tokenizes multiple imports with an alias for a multi-line declaration', ->
@@ -707,6 +729,10 @@ describe 'Go grammar', ->
         testImport kwd[0]
         testOpBracket kwd[2], '('
         testImportAlias decl[1], '.'
-        testImportPackage decl[3], 'github.com/test/package'
-        testImportPackage decl2[1], 'fmt'
+        testBeginQuoted decl[3]
+        testImportPackage decl[4], 'github.com/test/package'
+        testEndQuoted decl[5]
+        testBeginQuoted decl2[1]
+        testImportPackage decl2[2], 'fmt'
+        testEndQuoted decl2[3]
         testOpBracket closing[0], ')'


### PR DESCRIPTION
This adds two new scopes:

* `entity.alias.import.go`
* `entity.name.import.go`

This allows import declarations to be tokenized, and prevents them from being recognized as quoted strings. This paves the way for package autocompletion for single and multi-line import declarations:

### Single line import
`import "fmt"`

### Single line import with alias
`import aliasedfmt "fmt"`

### Multi line import
```
import (
    "fmt"
)
```

### Multi-line import with alias
```
import (
    aliasedfmt "fmt"
)
```

Fixes https://github.com/joefitzgerald/go-plus/issues/226
Requires https://github.com/joefitzgerald/autocomplete-go/pull/50 to allow autocompletion in import statements