### PR TITLE
fixed tab stop order for go snippet

### DIFF
--- a/snippets/language-go.cson
+++ b/snippets/language-go.cson
@@ -112,7 +112,7 @@
     'body': "http.Serve(\"${1::8080}\", ${2:nil})"
   'goroutine anonymous function':
     'prefix': 'go'
-    'body': 'go func($1) {\n\t$2\n}($0)'
+    'body': 'go func($2) {\n\t$3\n}($1)'
   'goroutine function':
     'prefix': 'gf'
     'body': 'go ${1:func}($0)'


### PR DESCRIPTION
This PR fixes the tab stop order in such a way that the first tab stops where arguments from the outer scopes are provided as arguments to the function which is executed within a new goroutine. The current behaviour stops the tab where you receive the arguments, which was counterintuitive for me. IMO the first thing you want to do is to provide something to a function. Then you can write the definitions to receive arguments. Further I am not sure why `$0` is used as tab stop identifier. This happens in several places of the language-go snippets. As far as I can see this does actually nothing to the order. According to the documentation there can also no reference to `$0` be found. What do you think? 
