### PR TITLE
Fix comments in imports

### DIFF
--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -8,22 +8,7 @@
 'foldingStopMarker': '(}|\\))\\s*$'
 'patterns': [
   {
-    'comment': 'Block comments'
-    'begin': '/\\*'
-    'end': '\\*/'
-    'captures':
-      '0':
-        'name': 'punctuation.definition.comment.go'
-    'name': 'comment.block.go'
-  }
-  {
-    'comment': 'Line comments'
-    'begin': '//'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.comment.go'
-    'end': '$'
-    'name': 'comment.line.double-slash.go'
+    'include': '#comments'
   }
   {
     'comment': 'Interpreted string literals'
@@ -178,6 +163,9 @@
           '5':
             'name': 'punctuation.definition.string.end.go'
       }
+      {
+        'include': '#comments'
+      }
     ]
     'end': '\\)'
     'endCaptures':
@@ -291,6 +279,25 @@
       {
         'match': '\\[|\\]'
         'name': 'punctuation.other.bracket.square.go'
+      }
+    ]
+  'comments':
+    'patterns': [
+      {
+        'begin': '/\\*'
+        'end': '\\*/'
+        'captures':
+          '0':
+            'name': 'punctuation.definition.comment.go'
+        'name': 'comment.block.go'
+      }
+      {
+        'begin': '//'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.go'
+        'end': '$'
+        'name': 'comment.line.double-slash.go'
       }
     ]
   'delimiters':

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -27,6 +27,14 @@ describe 'Go grammar', ->
     expect(tokens[2][0].value).toEqual '*/'
     expect(tokens[2][0].scopes).toEqual ['source.go', 'comment.block.go', 'punctuation.definition.comment.go']
 
+  it 'tokenizes comments in imports', ->
+    lines = grammar.tokenizeLines '''
+      import (
+        // comment!
+      )
+    '''
+    expect(lines[1][1]).toEqual value: '//', scopes: ['source.go', 'comment.line.double-slash.go', 'punctuation.definition.comment.go']
+
   it 'tokenizes strings', ->
     delims =
       'string.quoted.double.go': '"'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Fixes comments not being recognized in multiline imports.

### Alternate Designs

No alternate designs were considered.

### Benefits

Comments will be correctly highlighted in import regions, as expected.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #102 

@joefitzgerald I have no idea how specs work in language-go so feel free to move the one I added to the import section if needed.