### PR TITLE
Consolidate and improve variable matching

### DIFF
--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -121,6 +121,9 @@
     'name': 'constant.language.go'
   }
   {
+    'include': '#keywords'
+  }
+  {
     'comment': 'Package declarations'
     'match': '(?<=package)\\s+([a-zA-Z_]\\w*)'
     'captures':
@@ -180,66 +183,7 @@
         'name': 'entity.name.type.go'
   }
   {
-    'comment': 'Shorthand variable declaration and assignments'
-    'match': '[a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*(?=\\s*:=)'
-    'captures':
-      '0':
-        'patterns': [
-          {
-            'match': '[a-zA-Z_]\\w*'
-            'name': 'variable.other.assignment.go'
-          }
-          {
-            'include': '#delimiters'
-          }
-        ]
-  }
-  {
-    'comment': 'Assignments to existing variables'
-    'match': '(?<!var )\\s*([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(?=\\s*=[^=])'
-    'captures':
-      '1':
-        'patterns': [
-          {
-            'match': '[a-zA-Z_]\\w*'
-            'name': 'variable.other.assignment.go'
-          }
-          {
-            'include': '#delimiters'
-          }
-        ]
-  }
-  {
-    'comment': 'Single line variable declarations/assignments'
-    'match': '(?<=var)\\s+(.*)$'
-    'captures':
-      '1':
-        'patterns': [
-          {
-            'include': '#variables'
-          }
-        ]
-  }
-  {
-    'comment': 'Multiline variable declarations/assignments'
-    'begin': '(\\bvar\\b)\\s+(\\()'
-    'beginCaptures':
-      '1':
-        'name': 'keyword.var.go'
-      '2':
-        'name': 'punctuation.other.bracket.round.go'
-    'end': '\\)'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.other.bracket.round.go'
-    'patterns': [
-      {
-        'include': '#variables'
-      }
-      {
-        'include': '$self'
-      }
-    ]
+    'include': '#variables'
   }
   {
     'comment': 'Terminators'
@@ -251,9 +195,6 @@
   }
   {
     'include': '#delimiters'
-  }
-  {
-    'include': '#keywords'
   }
   {
     'include': '#operators'
@@ -468,10 +409,52 @@
       }
     ]
   'variables':
-    'comment': 'First add tests and make sure existing tests still pass when changing anything here!'
+    # First add tests and make sure existing tests still pass when changing anything here!
     'patterns': [
       {
-        'match': '([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)\\s*(=.*)'
+        # Assignments to existing variables
+        # a =
+        # a, b, whatever =
+        # TODO: This rule is currently redundant since none of the other variable rules
+        # check for var. However, in the future, I'd like to axe #keywords and make
+        # individual rules responsible for tokenizing keywords, at which point this will
+        # probably become more useful.
+        'match': '(?<!var)\\s*([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(?=\\s*=(?!=))'
+        'captures':
+          '1':
+            'patterns': [
+              {
+                'match': '[a-zA-Z_]\\w*'
+                'name': 'variable.other.assignment.go'
+              }
+              {
+                'include': '#delimiters'
+              }
+            ]
+      }
+      {
+        # Shorthand variable declaration and assignments
+        # var a :=
+        # var a, b :=
+        'match': '[a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*(?=\\s*:=)'
+        'captures':
+          '0':
+            'patterns': [
+              {
+                'match': '[a-zA-Z_]\\w*'
+                'name': 'variable.other.assignment.go'
+              }
+              {
+                'include': '#delimiters'
+              }
+            ]
+      }
+      {
+        # var a =
+        # var a string =
+        # var a, b =
+        # var a, b *c =
+        'match': '([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(\\s+\\*?[a-zA-Z_]\\w*\\s*)?(?=\\s*=)'
         'captures':
           '1':
             'patterns': [
@@ -491,32 +474,27 @@
             ]
       }
       {
-        'match': '([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(\\s+[\\*]?[a-zA-Z_]\\w*\\s*)(=.*)'
-        'captures':
+        # Multiline variable declarations/assignments
+        'begin': '(?<=var)\\s+(\\()'
+        'beginCaptures':
           '1':
-            'patterns': [
-              {
-                'match': '[a-zA-Z_]\\w*'
-                'name': 'variable.other.assignment.go'
-              }
-              {
-                'include': '#delimiters'
-              }
-            ]
-          '2':
-            'patterns': [
-              {
-                'include': '$self'
-              }
-            ]
-          '3':
-            'patterns': [
-              {
-                'include': '$self'
-              }
-            ]
+            'name': 'punctuation.other.bracket.round.go'
+        'end': '\\)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.other.bracket.round.go'
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
       }
       {
+        # var a
+        # var a string
+        # var a, b string
+        # a *b
+        # var a []string
         'match': '([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(\\s+[\\[\\]\\*]{0,3}[a-zA-Z_]\\w*\\s*[^=].*)'
         'captures':
           '1':

--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -434,8 +434,8 @@
       }
       {
         # Shorthand variable declaration and assignments
-        # var a :=
-        # var a, b :=
+        # a :=
+        # a, b :=
         'match': '[a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*(?=\\s*:=)'
         'captures':
           '0':

--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -415,10 +415,6 @@
         # Assignments to existing variables
         # a =
         # a, b, whatever =
-        # TODO: This rule is currently redundant since none of the other variable rules
-        # check for var. However, in the future, I'd like to axe #keywords and make
-        # individual rules responsible for tokenizing keywords, at which point this will
-        # probably become more useful.
         'match': '(?<!var)\\s*([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(?=\\s*=(?!=))'
         'captures':
           '1':
@@ -454,7 +450,7 @@
         # var a string =
         # var a, b =
         # var a, b *c =
-        'match': '([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(\\s+\\*?[a-zA-Z_]\\w*\\s*)?(?=\\s*=)'
+        'match': '(?<=var)\\s+([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(\\s+\\*?[a-zA-Z_]\\w*\\s*)?(?=\\s*=)'
         'captures':
           '1':
             'patterns': [
@@ -485,6 +481,28 @@
             'name': 'punctuation.other.bracket.round.go'
         'patterns': [
           {
+            # Copy of below, but without the leading var
+            # var (a *b)
+            'match': '([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(\\s+[\\[\\]\\*]{0,3}[a-zA-Z_]\\w*\\s*[^=].*)'
+            'captures':
+              '1':
+                'patterns': [
+                  {
+                    'match': '[a-zA-Z_]\\w*'
+                    'name': 'variable.other.declaration.go'
+                  }
+                  {
+                    'include': '#delimiters'
+                  }
+                ]
+              '2':
+                'patterns': [
+                  {
+                    'include': '$self'
+                  }
+                ]
+          }
+          {
             'include': '$self'
           }
         ]
@@ -493,9 +511,8 @@
         # var a
         # var a string
         # var a, b string
-        # a *b
         # var a []string
-        'match': '([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(\\s+[\\[\\]\\*]{0,3}[a-zA-Z_]\\w*\\s*[^=].*)'
+        'match': '(?<=var)\\s+([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(\\s+[\\[\\]\\*]{0,3}[a-zA-Z_]\\w*\\s*[^=].*)'
         'captures':
           '1':
             'patterns': [

--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -121,9 +121,6 @@
     'name': 'constant.language.go'
   }
   {
-    'include': '#keywords'
-  }
-  {
     'comment': 'Package declarations'
     'match': '(?<=package)\\s+([a-zA-Z_]\\w*)'
     'captures':
@@ -238,6 +235,9 @@
   }
   {
     'include': '#delimiters'
+  }
+  {
+    'include': '#keywords'
   }
   {
     'include': '#operators'

--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -475,30 +475,13 @@
             ]
       }
       {
-        # Multiline variable declarations/assignments
-        'begin': '(\\()'
-        'beginCaptures':
-          '1':
-            'name': 'punctuation.other.bracket.round.go'
-        'end': '\\)'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.other.bracket.round.go'
-        'patterns': [
-          {
-            'include': '#variables'
-          }
-          {
-            'include': '$self'
-          }
-        ]
-      }
-      {
         # var a
         # var a string
         # var a, b string
         # var a []string
-        'match': '([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(\\s+[\\[\\]\\*]{0,3}[a-zA-Z_]\\w*\\s*[^=].*)'
+        # var a [3]string
+        # var a [][]*string
+        'match': '([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(\\s+(\\[\\d*\\])*\\*?[a-zA-Z_]\\w*\\s*[^=].*)'
         'captures':
           '1':
             'patterns': [
@@ -516,5 +499,24 @@
                 'include': '$self'
               }
             ]
+      }
+      {
+        # Multiline variable declarations/assignments
+        'begin': '(\\()'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.other.bracket.round.go'
+        'end': '\\)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.other.bracket.round.go'
+        'patterns': [
+          {
+            'include': '#variables'
+          }
+          {
+            'include': '$self'
+          }
+        ]
       }
     ]

--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -183,7 +183,50 @@
         'name': 'entity.name.type.go'
   }
   {
-    'include': '#variables'
+    'begin': '\\b(var)\\s+'
+    'beginCaptures':
+      '1':
+        'name': 'keyword.var.go'
+    'end': '(?!\\G)'
+    'patterns': [
+      {
+        'include': '#variables'
+      }
+    ]
+  }
+  {
+    # Assignments to existing variables
+    # a =
+    # a, b, whatever =
+    'match': '(?<!var)\\s*([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(?=\\s*=(?!=))'
+    'captures':
+      '1':
+        'patterns': [
+          {
+            'match': '[a-zA-Z_]\\w*'
+            'name': 'variable.other.assignment.go'
+          }
+          {
+            'include': '#delimiters'
+          }
+        ]
+  }
+  {
+    # Shorthand variable declaration and assignments
+    # a :=
+    # a, b :=
+    'match': '[a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*(?=\\s*:=)'
+    'captures':
+      '0':
+        'patterns': [
+          {
+            'match': '[a-zA-Z_]\\w*'
+            'name': 'variable.other.assignment.go'
+          }
+          {
+            'include': '#delimiters'
+          }
+        ]
   }
   {
     'comment': 'Terminators'
@@ -299,10 +342,6 @@
         'match': '\\btype\\b'
         'name': 'keyword.type.go'
       }
-      {
-        'match': '\\bvar\\b'
-        'name': 'keyword.var.go'
-      }
     ]
   'operators':
     'comment': 'Note that the order here is very important!'
@@ -412,45 +451,11 @@
     # First add tests and make sure existing tests still pass when changing anything here!
     'patterns': [
       {
-        # Assignments to existing variables
-        # a =
-        # a, b, whatever =
-        'match': '(?<!var)\\s*([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(?=\\s*=(?!=))'
-        'captures':
-          '1':
-            'patterns': [
-              {
-                'match': '[a-zA-Z_]\\w*'
-                'name': 'variable.other.assignment.go'
-              }
-              {
-                'include': '#delimiters'
-              }
-            ]
-      }
-      {
-        # Shorthand variable declaration and assignments
-        # a :=
-        # a, b :=
-        'match': '[a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*(?=\\s*:=)'
-        'captures':
-          '0':
-            'patterns': [
-              {
-                'match': '[a-zA-Z_]\\w*'
-                'name': 'variable.other.assignment.go'
-              }
-              {
-                'include': '#delimiters'
-              }
-            ]
-      }
-      {
         # var a =
         # var a string =
         # var a, b =
         # var a, b *c =
-        'match': '(?<=var)\\s+([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(\\s+\\*?[a-zA-Z_]\\w*\\s*)?(?=\\s*=)'
+        'match': '([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(\\s+\\*?[a-zA-Z_]\\w*\\s*)?(?=\\s*=)'
         'captures':
           '1':
             'patterns': [
@@ -471,7 +476,7 @@
       }
       {
         # Multiline variable declarations/assignments
-        'begin': '(?<=var)\\s+(\\()'
+        'begin': '(\\()'
         'beginCaptures':
           '1':
             'name': 'punctuation.other.bracket.round.go'
@@ -481,26 +486,7 @@
             'name': 'punctuation.other.bracket.round.go'
         'patterns': [
           {
-            # Copy of below, but without the leading var
-            # var (a *b)
-            'match': '([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(\\s+[\\[\\]\\*]{0,3}[a-zA-Z_]\\w*\\s*[^=].*)'
-            'captures':
-              '1':
-                'patterns': [
-                  {
-                    'match': '[a-zA-Z_]\\w*'
-                    'name': 'variable.other.declaration.go'
-                  }
-                  {
-                    'include': '#delimiters'
-                  }
-                ]
-              '2':
-                'patterns': [
-                  {
-                    'include': '$self'
-                  }
-                ]
+            'include': '#variables'
           }
           {
             'include': '$self'
@@ -512,7 +498,7 @@
         # var a string
         # var a, b string
         # var a []string
-        'match': '(?<=var)\\s+([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(\\s+[\\[\\]\\*]{0,3}[a-zA-Z_]\\w*\\s*[^=].*)'
+        'match': '([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(\\s+[\\[\\]\\*]{0,3}[a-zA-Z_]\\w*\\s*[^=].*)'
         'captures':
           '1':
             'patterns': [

--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -502,9 +502,9 @@
       }
       {
         # Multiline variable declarations/assignments
-        'begin': '(\\()'
+        'begin': '\\('
         'beginCaptures':
-          '1':
+          '0':
             'name': 'punctuation.other.bracket.round.go'
         'end': '\\)'
         'endCaptures':

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -527,9 +527,25 @@ describe 'Go grammar', ->
         {tokens} = grammar.tokenizeLine 'var z blub = 7'
         testVar tokens[0]
         testVarAssignment tokens[2], 'z'
-        expect(tokens[3].scopes).toEqual ['source.go']
+        expect(tokens[3]).toEqual value: ' blub ', scopes: ['source.go']
         testOpAssignment tokens[4], '='
         testNum tokens[6], '7'
+
+      it 'does not tokenize more than necessary', ->
+        # This test is worded vaguely because it's hard to describe.
+        # Basically, make sure that the variable match isn't tokenizing the entire line
+        # in a (=.+) style match. This prevents multiline stuff after the assignment
+        # from working correctly, because match can only tokenize single lines.
+        lines = grammar.tokenizeLines '''
+          var multiline string = `wow!
+          this should work!`
+        '''
+        testVar lines[0][0]
+        testVarAssignment lines[0][2], 'multiline'
+        testStringType lines[0][4], 'string'
+        testOpAssignment lines[0][6], '='
+        expect(lines[0][8]).toEqual value: '`', scopes: ['source.go', 'string.quoted.raw.go', 'punctuation.definition.string.begin.go']
+        expect(lines[1][1]).toEqual value: '`', scopes: ['source.go', 'string.quoted.raw.go', 'punctuation.definition.string.end.go']
 
       it 'tokenizes multiple names and a type', ->
         {tokens} = grammar.tokenizeLine 'var U, V,  W  float64'

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -516,6 +516,26 @@ describe 'Go grammar', ->
         testVarDeclaration tokens[2], 's'
         testStringType tokens[6], 'string'
 
+      it 'tokenizes a single name and a type with length', ->
+        {tokens} = grammar.tokenizeLine 'var s [4]string'
+        testVar tokens[0]
+        testVarDeclaration tokens[2], 's'
+        expect(tokens[4]).toEqual value: '[', scopes: ['source.go', 'punctuation.other.bracket.square.go']
+        expect(tokens[5]).toEqual value: '4', scopes: ['source.go', 'constant.numeric.integer.go']
+        expect(tokens[6]).toEqual value: ']', scopes: ['source.go', 'punctuation.other.bracket.square.go']
+        testStringType tokens[7], 'string'
+
+      it 'tokenizes a single name and multi-dimensional types with an address', ->
+        {tokens} = grammar.tokenizeLine 'var e [][]*string'
+        testVar tokens[0]
+        testVarDeclaration tokens[2], 'e'
+        expect(tokens[4]).toEqual value: '[', scopes: ['source.go', 'punctuation.other.bracket.square.go']
+        expect(tokens[5]).toEqual value: ']', scopes: ['source.go', 'punctuation.other.bracket.square.go']
+        expect(tokens[6]).toEqual value: '[', scopes: ['source.go', 'punctuation.other.bracket.square.go']
+        expect(tokens[7]).toEqual value: ']', scopes: ['source.go', 'punctuation.other.bracket.square.go']
+        testOpAddress tokens[8], '*'
+        testStringType tokens[9], 'string'
+
       it 'tokenizes a single name and its initialization', ->
         {tokens} = grammar.tokenizeLine ' var k =  0'
         testVar tokens[1]

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -595,6 +595,11 @@ describe 'Go grammar', ->
         testVarAssignment tokens[5], 'found'
         testOpAssignment tokens[7], '='
 
+      it 'does not treat words that have a trailing var as a variable declaration', ->
+        {tokens} = grammar.tokenizeLine 'func test(envvar string)'
+        expect(tokens[4]).toEqual value: 'envvar ', scopes: ['source.go']
+        expect(tokens[5]).toEqual value: 'string', scopes: ['source.go', 'storage.type.string.go']
+
       describe 'in var statement blocks', ->
         it 'tokenizes single names with a type', ->
           [kwd, decl, closing] = grammar.tokenizeLines '\tvar (\n\t\tfoo *bar\n\t)'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

* Move all variable matches into #variables
* Prevent unnecessary tokenization (end at the equals sign)
* Fix assignments to existing variables
* Consolidate two existing variable matches into one
* Add support for multidimensional arrays with optional lengths
* Add examples

Prior to this PR, the variable matching rules would attempt to match all the way to the end of the line.  This is undesirable, because all it did was return control to `$self`.  However, since the rule was a simple `match`, this meant anything multiline would stop highlighting after the linebreak.
Now, variable rules only match _up to_ the equal sign.  This allows multiline rules to work correctly.

### Alternate Designs

None.

### Benefits

Multiline stuff after a variable assignment will be correctly matched.

### Possible Drawbacks

Should be none.

### Applicable Issues

Fixes #98
Fixes #103
Fixes Microsoft/vscode#22654