### PR TITLE
Tokenize variables starting with a non-ASCII letter

### DIFF
--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -80,7 +80,7 @@
   }
   {
     'comment': 'Function declarations'
-    'match': '^(\\bfunc\\b)(?:\\s+(\\([^\\)]+\\)\\s+)?([\\w&&[^0-9]]\\w*)(?=\\())?'
+    'match': '^(\\bfunc\\b)(?:\\s+(\\([^\\)]+\\)\\s+)?(\\w+)(?=\\())?'
     'captures':
       '1':
         'name': 'keyword.function.go'
@@ -94,16 +94,34 @@
           }
         ]
       '3':
-        'name': 'entity.name.function.go'
+        'patterns': [
+          {
+            'match': '\\d\\w*'
+            'name': 'invalid.illegal.identifier.go'
+          }
+          {
+            'match': '\\w+'
+            'name': 'entity.name.function.go'
+          }
+        ]
   }
   {
     'comment': 'Functions'
-    'match': '(\\bfunc\\b)|([\\w&&[^0-9]]\\w*)(?=\\()'
+    'match': '(\\bfunc\\b)|(\\w+)(?=\\()'
     'captures':
       '1':
         'name': 'keyword.function.go'
       '2':
-        'name': 'support.function.go'
+        'patterns': [
+          {
+            'match': '\\d\\w*'
+            'name': 'invalid.illegal.identifier.go'
+          }
+          {
+            'match': '\\w+'
+            'name': 'support.function.go'
+          }
+        ]
   }
   {
     'comment': 'Floating-point literals'
@@ -122,10 +140,19 @@
   }
   {
     'comment': 'Package declarations'
-    'match': '(?<=package)\\s+([\\w&&[^0-9]]\\w*)'
+    'match': '(?<=package)\\s+(\\w+)'
     'captures':
       '1':
-        'name': 'entity.name.package.go'
+        'patterns': [
+          {
+            'match': '\\d\\w*'
+            'name': 'invalid.illegal.identifier.go'
+          }
+          {
+            'match': '\\w+'
+            'name': 'entity.name.package.go'
+          }
+        ]
   }
   {
     'comment': 'Single line import declarations'
@@ -174,19 +201,32 @@
   }
   {
     'comment': 'Type declarations'
-    'match': '(?<=type)\\s+([\\w&&[^0-9]]\\w*)'
+    'match': '(?<=type)\\s+(\\w+)'
     'captures':
       '1':
-        'name': 'entity.name.type.go'
+        'patterns': [
+          {
+            'match': '\\d\\w*'
+            'name': 'invalid.illegal.identifier.go'
+          }
+          {
+            'match': '\\w+'
+            'name': 'entity.name.type.go'
+          }
+        ]
   }
   {
     'comment': 'Shorthand variable declaration and assignments'
-    'match': '[\\w&&[^0-9]]\\w*(?:,\\s*[\\w&&[^0-9]]\\w*)*(?=\\s*:=)'
+    'match': '\\w+(?:,\\s*\\w+)*(?=\\s*:=)'
     'captures':
       '0':
         'patterns': [
           {
-            'match': '[\\w&&[^0-9]]\\w*'
+            'match': '\\d\\w*'
+            'name': 'invalid.illegal.identifier.go'
+          }
+          {
+            'match': '\\w+'
             'name': 'variable.other.assignment.go'
           }
           {
@@ -196,12 +236,16 @@
   }
   {
     'comment': 'Assignments to existing variables'
-    'match': '(?<!var )\\s*([\\w&&[^0-9]]\\w*(?:,\\s*[\\w&&[^0-9]]\\w*)*)(?=\\s*=[^=])'
+    'match': '(?<!var )\\s*(\\w+(?:,\\s*\\w+)*)(?=\\s*=[^=])'
     'captures':
       '1':
         'patterns': [
           {
-            'match': '[\\w&&[^0-9]]\\w*'
+            'match': '\\d\\w*'
+            'name': 'invalid.illegal.identifier.go'
+          }
+          {
+            'match': '\\w+'
             'name': 'variable.other.assignment.go'
           }
           {
@@ -471,12 +515,16 @@
     'comment': 'First add tests and make sure existing tests still pass when changing anything here!'
     'patterns': [
       {
-        'match': '([\\w&&[^0-9]]\\w*(?:,\\s*[\\w&&[^0-9]]\\w*)*)\\s*(=.*)'
+        'match': '(\\w+(?:,\\s*\\w+)*)\\s*(=.*)'
         'captures':
           '1':
             'patterns': [
               {
-                'match': '[\\w&&[^0-9]]\\w*'
+                'match': '\\d\\w*'
+                'name': 'invalid.illegal.identifier.go'
+              }
+              {
+                'match': '\\w+'
                 'name': 'variable.other.assignment.go'
               }
               {
@@ -491,12 +539,16 @@
             ]
       }
       {
-        'match': '([\\w&&[^0-9]]\\w*(?:,\\s*[\\w&&[^0-9]]\\w*)*)(\\s+[\\*]?[\\w&&[^0-9]]\\w*\\s*)(=.*)'
+        'match': '(\\w+(?:,\\s*\\w+)*)(\\s+[\\*]?\\w+\\s*)(=.*)'
         'captures':
           '1':
             'patterns': [
               {
-                'match': '[\\w&&[^0-9]]\\w*'
+                'match': '\\d\\w*'
+                'name': 'invalid.illegal.identifier.go'
+              }
+              {
+                'match': '\\w+'
                 'name': 'variable.other.assignment.go'
               }
               {
@@ -517,12 +569,16 @@
             ]
       }
       {
-        'match': '([\\w&&[^0-9]]\\w*(?:,\\s*[\\w&&[^0-9]]\\w*)*)(\\s+[\\[\\]\\*]{0,3}[\\w&&[^0-9]]\\w*\\s*[^=].*)'
+        'match': '(\\w+(?:,\\s*\\w+)*)(\\s+[\\[\\]\\*]{0,3}\\w+\\s*[^=].*)'
         'captures':
           '1':
             'patterns': [
               {
-                'match': '[\\w&&[^0-9]]\\w*'
+                'match': '\\d\\w*'
+                'name': 'invalid.illegal.identifier.go'
+              }
+              {
+                'match': '\\w+'
                 'name': 'variable.other.declaration.go'
               }
               {

--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -80,7 +80,7 @@
   }
   {
     'comment': 'Function declarations'
-    'match': '^(\\bfunc\\b)(?:\\s+(\\([^\\)]+\\)\\s+)?([a-zA-Z_]\\w*)(?=\\())?'
+    'match': '^(\\bfunc\\b)(?:\\s+(\\([^\\)]+\\)\\s+)?([\\w&&[^0-9]]\\w*)(?=\\())?'
     'captures':
       '1':
         'name': 'keyword.function.go'
@@ -98,7 +98,7 @@
   }
   {
     'comment': 'Functions'
-    'match': '(\\bfunc\\b)|([a-zA-Z_]\\w*)(?=\\()'
+    'match': '(\\bfunc\\b)|([\\w&&[^0-9]]\\w*)(?=\\()'
     'captures':
       '1':
         'name': 'keyword.function.go'
@@ -122,7 +122,7 @@
   }
   {
     'comment': 'Package declarations'
-    'match': '(?<=package)\\s+([a-zA-Z_]\\w*)'
+    'match': '(?<=package)\\s+([\\w&&[^0-9]]\\w*)'
     'captures':
       '1':
         'name': 'entity.name.package.go'
@@ -174,19 +174,19 @@
   }
   {
     'comment': 'Type declarations'
-    'match': '(?<=type)\\s+([a-zA-Z_]\\w*)'
+    'match': '(?<=type)\\s+([\\w&&[^0-9]]\\w*)'
     'captures':
       '1':
         'name': 'entity.name.type.go'
   }
   {
     'comment': 'Shorthand variable declaration and assignments'
-    'match': '[a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*(?=\\s*:=)'
+    'match': '[\\w&&[^0-9]]\\w*(?:,\\s*[\\w&&[^0-9]]\\w*)*(?=\\s*:=)'
     'captures':
       '0':
         'patterns': [
           {
-            'match': '[a-zA-Z_]\\w*'
+            'match': '[\\w&&[^0-9]]\\w*'
             'name': 'variable.other.assignment.go'
           }
           {
@@ -196,12 +196,12 @@
   }
   {
     'comment': 'Assignments to existing variables'
-    'match': '(?<!var )\\s*([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(?=\\s*=[^=])'
+    'match': '(?<!var )\\s*([\\w&&[^0-9]]\\w*(?:,\\s*[\\w&&[^0-9]]\\w*)*)(?=\\s*=[^=])'
     'captures':
       '1':
         'patterns': [
           {
-            'match': '[a-zA-Z_]\\w*'
+            'match': '[\\w&&[^0-9]]\\w*'
             'name': 'variable.other.assignment.go'
           }
           {
@@ -471,12 +471,12 @@
     'comment': 'First add tests and make sure existing tests still pass when changing anything here!'
     'patterns': [
       {
-        'match': '([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)\\s*(=.*)'
+        'match': '([\\w&&[^0-9]]\\w*(?:,\\s*[\\w&&[^0-9]]\\w*)*)\\s*(=.*)'
         'captures':
           '1':
             'patterns': [
               {
-                'match': '[a-zA-Z_]\\w*'
+                'match': '[\\w&&[^0-9]]\\w*'
                 'name': 'variable.other.assignment.go'
               }
               {
@@ -491,12 +491,12 @@
             ]
       }
       {
-        'match': '([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(\\s+[\\*]?[a-zA-Z_]\\w*\\s*)(=.*)'
+        'match': '([\\w&&[^0-9]]\\w*(?:,\\s*[\\w&&[^0-9]]\\w*)*)(\\s+[\\*]?[\\w&&[^0-9]]\\w*\\s*)(=.*)'
         'captures':
           '1':
             'patterns': [
               {
-                'match': '[a-zA-Z_]\\w*'
+                'match': '[\\w&&[^0-9]]\\w*'
                 'name': 'variable.other.assignment.go'
               }
               {
@@ -517,12 +517,12 @@
             ]
       }
       {
-        'match': '([a-zA-Z_]\\w*(?:,\\s*[a-zA-Z_]\\w*)*)(\\s+[\\[\\]\\*]{0,3}[a-zA-Z_]\\w*\\s*[^=].*)'
+        'match': '([\\w&&[^0-9]]\\w*(?:,\\s*[\\w&&[^0-9]]\\w*)*)(\\s+[\\[\\]\\*]{0,3}[\\w&&[^0-9]]\\w*\\s*[^=].*)'
         'captures':
           '1':
             'patterns': [
               {
-                'match': '[a-zA-Z_]\\w*'
+                'match': '[\\w&&[^0-9]]\\w*'
                 'name': 'variable.other.declaration.go'
               }
               {

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -630,6 +630,11 @@ describe 'Go grammar', ->
           testNum init[6], '10'
           testOpBracket closing[0], ')'
 
+        it 'tokenizes non-ASCII variable names', ->
+          {tokens} = grammar.tokenizeLine 'über = test'
+          testVarAssignment tokens[0], 'über'
+          testOpAssignment tokens[2], '='
+
       describe 'in shorthand variable declarations', ->
         it 'tokenizes single names', ->
           {tokens} = grammar.tokenizeLine 'f := func() int { return 7 }'

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -427,6 +427,11 @@ describe 'Go grammar', ->
       expect(tokens[0].scopes).toEqual ['source.go', 'keyword.package.go']
       expect(tokens[2].scopes).toEqual ['source.go', 'entity.name.package.go']
 
+  it 'tokenizes invalid package names as such', ->
+    {tokens} = grammar.tokenizeLine 'package 0mypackage'
+    expect(tokens[0]).toEqual value: 'package', scopes: ['source.go', 'keyword.package.go']
+    expect(tokens[2]).toEqual value: '0mypackage', scopes: ['source.go', 'invalid.illegal.identifier.go']
+
   it 'tokenizes type names', ->
     tests = ['type mystring string', 'type mytype interface{']
 
@@ -434,6 +439,11 @@ describe 'Go grammar', ->
       {tokens} = grammar.tokenizeLine test
       expect(tokens[0].scopes).toEqual ['source.go', 'keyword.type.go']
       expect(tokens[2].scopes).toEqual ['source.go', 'entity.name.type.go']
+
+  it 'tokenizes invalid type names as such', ->
+    {tokens} = grammar.tokenizeLine 'type 0mystring string'
+    expect(tokens[0]).toEqual value: 'type', scopes: ['source.go', 'keyword.type.go']
+    expect(tokens[2]).toEqual value: '0mystring', scopes: ['source.go', 'invalid.illegal.identifier.go']
 
   describe 'in variable declarations', ->
     testVar = (token) ->
@@ -634,6 +644,11 @@ describe 'Go grammar', ->
           {tokens} = grammar.tokenizeLine 'über = test'
           testVarAssignment tokens[0], 'über'
           testOpAssignment tokens[2], '='
+
+        it 'tokenizes invalid variable names as such', ->
+          {tokens} = grammar.tokenizeLine 'var 0test = 0'
+          testVar tokens[0]
+          expect(tokens[2]).toEqual value: '0test', scopes: ['source.go', 'invalid.illegal.identifier.go']
 
       describe 'in shorthand variable declarations', ->
         it 'tokenizes single names', ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Instead of checking to make sure that the first letter of a variable is part of the US alphabet, check instead that it is a word character and NOT a number.  This is primarily for non-ASCII variables.

### Alternate Designs

/cc @pchaigno, @Alhadis: In the event that language-go is used to highlight Go code on GitHub in the future, I want to make sure that this syntax will be recognized by the engine that GitHub uses.
/cc @esdoppio: I saw that an alternative was `\p{L}`.  In the event that both are recognized, which would you prefer?  I know in the past that you've been using `[\w&&[^0-9]]`, but `\p{L}` seems much cleaner to me.

### Benefits

See description.

### Possible Drawbacks

See alternatives :).

### Applicable Issues

Fixes #93