### PR TITLE
Don't require a word before an opening bracket when indenting

### DIFF
--- a/settings/language-go.cson
+++ b/settings/language-go.cson
@@ -1,6 +1,6 @@
 '.source.go':
   'editor':
     'commentStart': '// '
-    'increaseIndentPattern': '^.*(\\bcase\\b.*:|\\bdefault\\b:|(\\b(func|if|else|switch|select|for|struct)\\b.*|\\w)\\{[^}]*|\\([^)]*)$'
-    'decreaseIndentPattern': '^\\s*(\\bcase\\b.*:|\\bdefault\\b:|\\}[),]?|\\)[,]?)$'
+    'increaseIndentPattern': '^.*(\\bcase\\b.*:|\\bdefault\\b:|(\\b(func|if|else|switch|select|for|struct)\\b.*)?{[^}]*|\\([^)]*)$'
+    'decreaseIndentPattern': '^\\s*(\\bcase\\b.*:|\\bdefault\\b:|}[),]?|\\)[,]?)$'
     'decreaseNextIndentPattern': '^\\s*[^\\s()}]+(?<m>[^()]*\\((?:\\g<m>[^()]*|[^()]*)\\))*[^()]*\\)[,]?$'

--- a/spec/language-go-spec.coffee
+++ b/spec/language-go-spec.coffee
@@ -30,6 +30,7 @@ describe 'Go settings', ->
     expect(increaseIndentRegex.testSync('  for i := 0; i < 10; i++ {')).toBeTruthy()
     expect(increaseIndentRegex.testSync('  type something struct {')).toBeTruthy()
     expect(increaseIndentRegex.testSync('  fmt.Printf("some%s",')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('  aSlice := []string{}{')).toBeTruthy()
 
   it 'matches lines correctly using the decreaseIndentPattern', ->
     decreaseIndentRegex = languageMode.decreaseIndentRegexForScopeDescriptor(['source.go'])


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Pretty self-explanatory.  If an opening bracket exists without any closing brackets, we should probably indent.  The `decreaseIndentPattern` change is purely cosmetic.

### Alternate Designs

None.

### Benefits

Improved auto-indentation.

### Possible Drawbacks

There hopefully should be none.

### Applicable Issues

Fixes #87