### PR TITLE
A fix for ‘type’ related BUG

### DIFF
--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -174,7 +174,7 @@
   }
   {
     'comment': 'Type declarations'
-    'match': '(?<=type)\\s+([a-zA-Z_]\\w*)'
+    'match': '(?:(?<=[^\\w]type)\\s+|(?<=^type)\\s+)([a-zA-Z_]\\w*)'
     'captures':
       '1':
         'name': 'entity.name.type.go'

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -572,6 +572,11 @@ describe 'Go grammar', ->
         testVarAssignment tokens[5], 'im'
         testOpAssignment tokens[7], '='
 
+      it 'does not treat words that have a trailing type as a type declaration', ->
+        {tokens} = grammar.tokenizeLine 'func test(envtype string)'
+        expect(tokens[4]).toEqual value: 'envtype ', scopes: ['source.go']
+        expect(tokens[5]).toEqual value: 'string', scopes: ['source.go', 'storage.type.string.go']
+
       it 'tokenizes with a placeholder', ->
         {tokens} = grammar.tokenizeLine 'var _, found = entries[name]'
         testVar tokens[0]


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

- When matching the keyword `type`, it should always begin at word boundary or begin of a line

### Alternate Designs

None

### Benefits

- Correct the syntax highlighting when a variable ends with lowercase word `type`

### Possible Drawbacks

Should be none.

### Applicable Issues

Fixes #91