### PR TITLE
Remove usage of lookbehinds

### DIFF
--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -139,83 +139,58 @@
     'name': 'constant.language.go'
   }
   {
-    'comment': 'Package declarations'
-    'match': '(?<=package)\\s+(\\w+)'
-    'captures':
-      '1':
-        'patterns': [
-          {
-            'match': '\\d\\w*'
-            'name': 'invalid.illegal.identifier.go'
-          }
-          {
-            'match': '\\w+'
-            'name': 'entity.name.package.go'
-          }
-        ]
-  }
-  {
-    'comment': 'Single line import declarations'
-    'match': '(?<=import)(\\s+((?!\\s+")[^\\s]*)?\\s*)((")([^"]*)("))'
-    'captures':
-      '2':
-        'name': 'entity.alias.import.go'
-      '3':
-        'name': 'string.quoted.double.go'
-      '4':
-        'name': 'punctuation.definition.string.begin.go'
-      '5':
-        'name': 'entity.name.import.go'
-      '6':
-        'name': 'punctuation.definition.string.end.go'
-  }
-  {
-    'comment': 'Multiline import declarations'
-    'begin': '(?<=import)\\s+(\\()'
+    # Package declarations
+    # Using a begin/end here allows us to match the package keyword before the package name is typed
+    'begin': '\\b(package)\\s+'
     'beginCaptures':
       '1':
-        'name': 'punctuation.other.bracket.round.go'
+        'name': 'keyword.package.go'
+    'end': '(?!\\G)'
     'patterns': [
       {
-        'match': '((?!\\s+")[^\\s]*)?\\s+((")([^"]*)("))'
-        'captures':
-          '1':
-            'name': 'entity.alias.import.go'
-          '2':
-            'name': 'string.quoted.double.go'
-          '3':
-            'name': 'punctuation.definition.string.begin.go'
-          '4':
-            'name': 'entity.name.import.go'
-          '5':
-            'name': 'punctuation.definition.string.end.go'
+        'match': '\\d\\w*'
+        'name': 'invalid.illegal.identifier.go'
       }
       {
-        'include': '#comments'
+        'match': '\\w+'
+        'name': 'entity.name.package.go'
       }
     ]
-    'end': '\\)'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.other.bracket.round.go'
   }
   {
-    'comment': 'Type declarations'
-    'match': '(?<=type)\\s+(\\w+)'
-    'captures':
+    # Type declarations
+    # Using a begin/end here allows us to match the type keyword before the type name is typed
+    'begin': '\\b(type)\\s+'
+    'beginCaptures':
       '1':
-        'patterns': [
-          {
-            'match': '\\d\\w*'
-            'name': 'invalid.illegal.identifier.go'
-          }
-          {
-            'match': '\\w+'
-            'name': 'entity.name.type.go'
-          }
-        ]
+        'name': 'keyword.type.go'
+    'end': '(?!\\G)'
+    'patterns': [
+      {
+        'match': '\\d\\w*'
+        'name': 'invalid.illegal.identifier.go'
+      }
+      {
+        'match': '\\w+'
+        'name': 'entity.name.type.go'
+      }
+    ]
   }
   {
+    # Imports
+    'begin': '\\b(import)\\s+'
+    'beginCaptures':
+      '1':
+        'name': 'keyword.import.go'
+    'end': '(?!\\G)'
+    'patterns': [
+      {
+        'include': '#imports'
+      }
+    ]
+  }
+  {
+    # Variables
     'begin': '\\b(var)\\s+'
     'beginCaptures':
       '1':
@@ -343,6 +318,43 @@
         'name': 'punctuation.other.colon.go'
       }
     ]
+  'imports':
+    'patterns': [
+      {
+        # Single line import declarations
+        'match': '((?!\\s+")[^\\s]*)?\\s*((")([^"]*)("))'
+        'captures':
+          '1':
+            'name': 'entity.alias.import.go'
+          '2':
+            'name': 'string.quoted.double.go'
+          '3':
+            'name': 'punctuation.definition.string.begin.go'
+          '4':
+            'name': 'entity.name.import.go'
+          '5':
+            'name': 'punctuation.definition.string.end.go'
+      }
+      {
+        # Multiline import declarations
+        'begin': '\\('
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.other.bracket.round.go'
+        'end': '\\)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.other.bracket.round.go'
+        'patterns': [
+          {
+            'include': '#imports'
+          }
+          {
+            'include': '#comments'
+          }
+        ]
+      }
+    ]
   'keywords':
     'patterns': [
       {
@@ -367,24 +379,12 @@
         'name': 'keyword.interface.go'
       }
       {
-        'match': '\\bimport\\b'
-        'name': 'keyword.import.go'
-      }
-      {
         'match': '\\bmap\\b'
         'name': 'keyword.map.go'
       }
       {
-        'match': '\\bpackage\\b'
-        'name': 'keyword.package.go'
-      }
-      {
         'match': '\\bstruct\\b'
         'name': 'keyword.struct.go'
-      }
-      {
-        'match': '\\btype\\b'
-        'name': 'keyword.type.go'
       }
     ]
   'operators':

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -434,8 +434,8 @@ describe 'Go grammar', ->
 
   it 'does not treat words that have a trailing package as a package name', ->
     {tokens} = grammar.tokenizeLine 'func myFunc(Varpackage string)'
-    expect(tokens[5]).toEqual value: 'Varpackage', scopes: ['source.go']
-    expect(tokens[6]).toEqual value: 'string', scopes: ['source.go', 'storage.type.string.go']
+    expect(tokens[4]).toEqual value: 'Varpackage ', scopes: ['source.go']
+    expect(tokens[5]).toEqual value: 'string', scopes: ['source.go', 'storage.type.string.go']
 
   it 'tokenizes type names', ->
     tests = ['type mystring string', 'type mytype interface{']
@@ -452,8 +452,8 @@ describe 'Go grammar', ->
 
   it 'does not treat words that have a trailing type as a type name', ->
     {tokens} = grammar.tokenizeLine 'func myFunc(Vartype string)'
-    expect(tokens[5]).toEqual value: 'Vartype', scopes: ['source.go']
-    expect(tokens[6]).toEqual value: 'string', scopes: ['source.go', 'storage.type.string.go']
+    expect(tokens[4]).toEqual value: 'Vartype ', scopes: ['source.go']
+    expect(tokens[5]).toEqual value: 'string', scopes: ['source.go', 'storage.type.string.go']
 
   describe 'in variable declarations', ->
     testVar = (token) ->
@@ -773,8 +773,8 @@ describe 'Go grammar', ->
 
       it 'does not treat words that have a trailing import as a import declaration', ->
         {tokens} = grammar.tokenizeLine 'func myFunc(Varimport string)'
-        expect(tokens[5]).toEqual value: 'Varimport', scopes: ['source.go']
-        expect(tokens[6]).toEqual value: 'string', scopes: ['source.go', 'storage.type.string.go']
+        expect(tokens[4]).toEqual value: 'Varimport ', scopes: ['source.go']
+        expect(tokens[5]).toEqual value: 'string', scopes: ['source.go', 'storage.type.string.go']
 
     describe 'when it is a multi line declaration', ->
       it 'tokenizes single declarations with a package name', ->

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -432,6 +432,11 @@ describe 'Go grammar', ->
     expect(tokens[0]).toEqual value: 'package', scopes: ['source.go', 'keyword.package.go']
     expect(tokens[2]).toEqual value: '0mypackage', scopes: ['source.go', 'invalid.illegal.identifier.go']
 
+  it 'does not treat words that have a trailing package as a package name', ->
+    {tokens} = grammar.tokenizeLine 'func myFunc(Varpackage string)'
+    expect(tokens[5]).toEqual value: 'Varpackage', scopes: ['source.go']
+    expect(tokens[6]).toEqual value: 'string', scopes: ['source.go', 'storage.type.string.go']
+
   it 'tokenizes type names', ->
     tests = ['type mystring string', 'type mytype interface{']
 
@@ -444,6 +449,11 @@ describe 'Go grammar', ->
     {tokens} = grammar.tokenizeLine 'type 0mystring string'
     expect(tokens[0]).toEqual value: 'type', scopes: ['source.go', 'keyword.type.go']
     expect(tokens[2]).toEqual value: '0mystring', scopes: ['source.go', 'invalid.illegal.identifier.go']
+
+  it 'does not treat words that have a trailing type as a type name', ->
+    {tokens} = grammar.tokenizeLine 'func myFunc(Vartype string)'
+    expect(tokens[5]).toEqual value: 'Vartype', scopes: ['source.go']
+    expect(tokens[6]).toEqual value: 'string', scopes: ['source.go', 'storage.type.string.go']
 
   describe 'in variable declarations', ->
     testVar = (token) ->
@@ -760,6 +770,11 @@ describe 'Go grammar', ->
         testBeginQuoted tokens[4]
         testImportPackage tokens[5], 'github.com/test/package'
         testEndQuoted tokens[6]
+
+      it 'does not treat words that have a trailing import as a import declaration', ->
+        {tokens} = grammar.tokenizeLine 'func myFunc(Varimport string)'
+        expect(tokens[5]).toEqual value: 'Varimport', scopes: ['source.go']
+        expect(tokens[6]).toEqual value: 'string', scopes: ['source.go', 'storage.type.string.go']
 
     describe 'when it is a multi line declaration', ->
       it 'tokenizes single declarations with a package name', ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Following #111, this PR removes the usage of positive lookbehinds from the remaining three keywords that use them: package, import, and type.  The main reason for doing so is because lookbehinds cannot be variable-width; this means that issues like #91 happen quite easily.  In addition, now that the keywords are tokenized alongside the content, it makes the patterns more readable and also allows a refactoring of the import patterns (similar to the variable refactor).

### Alternate Designs

#116 was considered, but that adds more complexity to the lookbehind.  In comparison, this PR simplifies the patterns and makes them easier to understand.

### Benefits

Code that is easier to understand and should be less prone to breakage.

### Possible Drawbacks

I don't see any.

### Applicable Issues

Fixes #91
Supersedes and closes #116