### PR TITLE
Add string scopes to runes

### DIFF
--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -442,12 +442,25 @@
   'runes':
     'patterns': [
       {
-        'match': '\\\'(\\\\([0-7]{3}|[abfnrtv\\\\\'"]|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8})|\\\p{Any})\\\''
-        'name': 'constant.other.rune.go'
-      }
-      {
-        'match': '\\\'.*\\\''
-        'name': 'invalid.illegal.unknown-rune.go'
+        'begin': "'"
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.go'
+        'end': "'"
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.go'
+        'name': 'string.quoted.rune.go'
+        'patterns': [
+          {
+            'match': "\\G(\\\\([0-7]{3}|[abfnrtv\\\\'\"]|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8})|.)(?=')"
+            'name': 'constant.other.rune.go'
+          }
+          {
+            'match': "[^']+"
+            'name': 'invalid.illegal.unknown-rune.go'
+          }
+        ]
       }
     ]
   'storage_types':

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -108,25 +108,33 @@ describe 'Go grammar', ->
       expect(tokens[2].scopes).toEqual ['source.go', 'string.quoted.raw.go', 'punctuation.definition.string.end.go']
 
   it 'tokenizes runes', ->
-    verbs = [
+    runes = [
       'u', 'X', '$', ':', '(', '.', '2', '=', '!', '@',
-      '\\a', '\\b', '\\f', '\\n', '\\r', '\\t', '\\v', '\\\\'
+      '\\a', '\\b', '\\f', '\\n', '\\r', '\\t', '\\v', '\\\\', "\\'", '\\"',
       '\\000', '\\007', '\\377', '\\x07', '\\xff', '\\u12e4', '\\U00101234'
     ]
 
-    for verb in verbs
-      {tokens} = grammar.tokenizeLine('\'' + verb + '\'')
-      expect(tokens[0].value).toEqual '\'' + verb + '\'',
-      expect(tokens[0].scopes).toEqual ['source.go', 'constant.other.rune.go']
+    for rune in runes
+      {tokens} = grammar.tokenizeLine("'#{rune}'")
+      expect(tokens[0]).toEqual value: "'", scopes: ['source.go', 'string.quoted.rune.go', 'punctuation.definition.string.begin.go']
+      expect(tokens[1]).toEqual value: rune, scopes: ['source.go', 'string.quoted.rune.go', 'constant.other.rune.go']
+      expect(tokens[2]).toEqual value: "'", scopes: ['source.go', 'string.quoted.rune.go', 'punctuation.definition.string.end.go']
 
   it 'tokenizes invalid runes and single quoted strings', ->
-    {tokens} = grammar.tokenizeLine('\'ab\'')
-    expect(tokens[0].value).toEqual '\'ab\''
-    expect(tokens[0].scopes).toEqual ['source.go', 'invalid.illegal.unknown-rune.go']
+    {tokens} = grammar.tokenizeLine("'\\c'")
+    expect(tokens[0]).toEqual value: "'", scopes: ['source.go', 'string.quoted.rune.go', 'punctuation.definition.string.begin.go']
+    expect(tokens[1]).toEqual value: '\\c', scopes: ['source.go', 'string.quoted.rune.go', 'invalid.illegal.unknown-rune.go']
+    expect(tokens[2]).toEqual value: "'", scopes: ['source.go', 'string.quoted.rune.go', 'punctuation.definition.string.end.go']
 
-    {tokens} = grammar.tokenizeLine('\'some single quote string\'')
-    expect(tokens[0].value).toEqual '\'some single quote string\''
-    expect(tokens[0].scopes).toEqual ['source.go', 'invalid.illegal.unknown-rune.go']
+    {tokens} = grammar.tokenizeLine("'ab'")
+    expect(tokens[0]).toEqual value: "'", scopes: ['source.go', 'string.quoted.rune.go', 'punctuation.definition.string.begin.go']
+    expect(tokens[1]).toEqual value: 'ab', scopes: ['source.go', 'string.quoted.rune.go', 'invalid.illegal.unknown-rune.go']
+    expect(tokens[2]).toEqual value: "'", scopes: ['source.go', 'string.quoted.rune.go', 'punctuation.definition.string.end.go']
+
+    {tokens} = grammar.tokenizeLine("'some single quote string'")
+    expect(tokens[0]).toEqual value: "'", scopes: ['source.go', 'string.quoted.rune.go', 'punctuation.definition.string.begin.go']
+    expect(tokens[1]).toEqual value: 'some single quote string', scopes: ['source.go', 'string.quoted.rune.go', 'invalid.illegal.unknown-rune.go']
+    expect(tokens[2]).toEqual value: "'", scopes: ['source.go', 'string.quoted.rune.go', 'punctuation.definition.string.end.go']
 
   it 'tokenizes invalid whitespace around chan annotations', ->
     invalid_send =


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Instead of tokenizing the entire string as a constant, add the standard string scopes and only tokenize the character _inside_ of the string as a rune constant.  Some improper escapes have also been removed, and `\p{Any}` has been changed to `.` (which seems to be the same thing).

### Alternate Designs

None.

### Benefits

Runes will receive proper string highlighting.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #129