### PR TITLE
Support deeply nested variable names

### DIFF
--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -207,7 +207,7 @@
     # a =
     # a, b, whatever =
     # a.b, c.d =
-    'match': '(?<!var)\\s*(\\w+(?:\\.\\w+)?(?:,\\s*\\w+(?:\\.\\w+)?)*)(?=\\s*=(?!=))'
+    'match': '(?<!var)\\s*(\\w+(?:\\.\\w+)*(?>,\\s*\\w+(?:\\.\\w+)*)*)(?=\\s*=(?!=))'
     'captures':
       '1':
         'patterns': [
@@ -216,7 +216,7 @@
             'name': 'invalid.illegal.identifier.go'
           }
           {
-            'match': '\\w+(?:\\.\\w+)?'
+            'match': '\\w+(?:\\.\\w+)*'
             'name': 'variable.other.assignment.go'
             'captures':
               '0':

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -525,12 +525,14 @@ describe 'Go grammar', ->
         testNum tokens[4], '7'
 
       it 'tokenizes a single qualified variable assignment', ->
-        {tokens} = grammar.tokenizeLine 'a.b = 7'
+        {tokens} = grammar.tokenizeLine 'a.b.cde = 7'
         expect(tokens[0]).toEqual value: 'a', scopes: ['source.go', 'variable.other.assignment.go']
         expect(tokens[1]).toEqual value: '.', scopes: ['source.go', 'variable.other.assignment.go', 'punctuation.other.period.go']
         expect(tokens[2]).toEqual value: 'b', scopes: ['source.go', 'variable.other.assignment.go']
-        testOpAssignment tokens[4], '='
-        testNum tokens[6], '7'
+        expect(tokens[3]).toEqual value: '.', scopes: ['source.go', 'variable.other.assignment.go', 'punctuation.other.period.go']
+        expect(tokens[4]).toEqual value: 'cde', scopes: ['source.go', 'variable.other.assignment.go']
+        testOpAssignment tokens[6], '='
+        testNum tokens[8], '7'
 
       it 'tokenizes multiple variable assignments', ->
         {tokens} = grammar.tokenizeLine 'i, j = 7, 8'
@@ -542,7 +544,7 @@ describe 'Go grammar', ->
         testNum tokens[10], '8'
 
       it 'tokenizes multiple qualified variable assignment', ->
-        {tokens} = grammar.tokenizeLine 'a.b, c.d = 7, 8'
+        {tokens} = grammar.tokenizeLine 'a.b, c.d.efg = 7, 8'
         expect(tokens[0]).toEqual value: 'a', scopes: ['source.go', 'variable.other.assignment.go']
         expect(tokens[1]).toEqual value: '.', scopes: ['source.go', 'variable.other.assignment.go', 'punctuation.other.period.go']
         expect(tokens[2]).toEqual value: 'b', scopes: ['source.go', 'variable.other.assignment.go']
@@ -550,9 +552,11 @@ describe 'Go grammar', ->
         expect(tokens[5]).toEqual value: 'c', scopes: ['source.go', 'variable.other.assignment.go']
         expect(tokens[6]).toEqual value: '.', scopes: ['source.go', 'variable.other.assignment.go', 'punctuation.other.period.go']
         expect(tokens[7]).toEqual value: 'd', scopes: ['source.go', 'variable.other.assignment.go']
-        testOpAssignment tokens[9], '='
-        testNum tokens[11], '7'
-        testNum tokens[14], '8'
+        expect(tokens[8]).toEqual value: '.', scopes: ['source.go', 'variable.other.assignment.go', 'punctuation.other.period.go']
+        expect(tokens[9]).toEqual value: 'efg', scopes: ['source.go', 'variable.other.assignment.go']
+        testOpAssignment tokens[11], '='
+        testNum tokens[13], '7'
+        testNum tokens[16], '8'
 
       it 'tokenizes a single name and a type', ->
         {tokens} = grammar.tokenizeLine 'var i int'


### PR DESCRIPTION
Changes the optional match for accessors to a multiple match, and changes the non-capturing group to an atomic group to avoid potential catastrophic backtracking.

Fixes #135