### PR TITLE
fixed go's function declaration syntax rule

### DIFF
--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -80,7 +80,7 @@
   }
   {
     'comment': 'Function declarations'
-    'match': '^(\\bfunc\\b)(?:\\s+(\\([^\\)]+\\)\\s+)?(\\w+)(?=\\())?'
+    'match': '^(\\bfunc\\b)(?:\\s+(\\([^\\)]+\\)\\s+)?(\\w+)\\s*(?=\\())?'
     'captures':
       '1':
         'name': 'keyword.function.go'


### PR DESCRIPTION
The grammar used to highlight function declaration syntax is designed to support only formatted code, which works great:

<img width="348" alt="screen shot 2017-11-02 at 11 57 37 pm" src="https://user-images.githubusercontent.com/2157285/32349237-9357c41c-c02b-11e7-992b-799df73d0529.png">

But for people who may prefer custom coding style or for when they're only typing not well formatted code the declaration syntax is not working because the optional white spacing is forgotten between function name and left parentheses as such:

<img width="769" alt="screen shot 2017-11-02 at 11 57 14 pm" src="https://user-images.githubusercontent.com/2157285/32349232-90d851d4-c02b-11e7-88f7-f8c61ac599d9.png">

This PR adds a tiny `\s*` in between of function name and the ending lookahead phrase to make sure all codes render right