### PR TITLE
Update keyword.operator.comparison.go regex

### DIFF
--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -437,7 +437,7 @@
         'name': 'keyword.operator.increment.go'
       }
       {
-        'match': '(==|!=|<=|>=|<[^<]|>[^>])'
+        'match': '(==|!=|<=|>=|<(?!<)|>(?!>))'
         'name': 'keyword.operator.comparison.go'
       }
       {

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -351,6 +351,15 @@ describe 'Go grammar', ->
         expect(tokens[0].value).toEqual op[0]
         expect(tokens[0].scopes).toEqual ['source.go', scope]
 
+  it 'does not treat values/variables attached to comparion operators as extensions of the operator', ->
+    {tokens} = grammar.tokenizeLine '2<3.0 && 12>bar'
+    expect(tokens[0]).toEqual value: '2', scopes: ['source.go', 'constant.numeric.integer.go']
+    expect(tokens[1]).toEqual value: '<', scopes: ['source.go', 'keyword.operator.comparison.go']
+    expect(tokens[2]).toEqual value: '3.0', scopes: ['source.go', 'constant.numeric.floating-point.go']
+    expect(tokens[6]).toEqual value: '12', scopes: ['source.go', 'constant.numeric.integer.go']
+    expect(tokens[7]).toEqual value: '>', scopes: ['source.go', 'keyword.operator.comparison.go']
+    expect(tokens[8]).toEqual value: 'bar', scopes: ['source.go']
+
   it 'tokenizes punctuation brackets', ->
     {tokens} = grammar.tokenizeLine '{([])}'
     expect(tokens[0]).toEqual value: '{', scopes: ['source.go', 'punctuation.definition.begin.bracket.curly.go']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The regex to match `keyword.operator.comparison.go`
`(==|!=|<=|>=|<[^<]|>[^>])`
contains a mistake introduced to avoid matching the bitshift operators. `[^<]` and `[^>]` will match anything following the first less/greater than symbol (this highlights <3 and >3 and is even more obvious with `<3.0` or `>2.0 `
The correct regex is
`(==|!=|<=|>=|<(?!<)|>(?!>))`
as it uses negative lookaheads to avoid highlighting characters immediately following the less/greater than symbol.


### Alternate Designs

If the negative lookahead is considered to be too greedy, the regex catching the bitwise operators could be placed before this regex and thus allowing to remove `[^<]` and `[^>]` from this regex.

### Benefits

Resolving several minor erroneous syntax highlights involving the less than/greater than operators.

### Possible Drawbacks

No drawbacks identified so far.

### Applicable Issues

Syntax highlights of anything in the regex format of:
`<[a-zA-Z0-9]`
e.g. `<3` `>2.5` `<i` and more with this syntax
