### PR TITLE
Add tree-sitter parser

### DIFF
--- a/grammars/tree-sitter-go.cson
+++ b/grammars/tree-sitter-go.cson
@@ -36,7 +36,7 @@ scopes:
   '"map"': 'keyword.map'
   '"chan"': 'keyword.chan'
 
-  'type_identifier': 'support.type'
+  'type_identifier': 'support.storage.type'
   'field_identifier': 'variable.other.object.property'
   'package_identifier': 'entity.name.package'
 
@@ -61,3 +61,9 @@ scopes:
   'function_declaration > identifier': 'entity.name.function'
   'method_declaration > field_identifier': 'entity.name.function'
   'call_expression > selector_expression > field_identifier': 'entity.name.function'
+
+  '":="': 'keyword.operator'
+  '"&"': 'keyword.operator'
+  '"*"': 'keyword.operator'
+  '"&&"': 'keyword.operator'
+  '"||"': 'keyword.operator'

--- a/grammars/tree-sitter-go.cson
+++ b/grammars/tree-sitter-go.cson
@@ -2,6 +2,7 @@ id: 'go'
 name: 'Go'
 type: 'tree-sitter'
 parser: 'tree-sitter-go'
+legacyScopeName: 'source.go'
 
 fileTypes: [
   'go'

--- a/grammars/tree-sitter-go.cson
+++ b/grammars/tree-sitter-go.cson
@@ -10,17 +10,23 @@ fileTypes: [
 comments:
   start: '// '
 
-folds:
-  delimiters: [
-    ['{', '}']
-    ['(', ')']
-    ['[', ']']
-  ]
-
-  nodes: [
-    'comment'
-    'raw_string_literal'
-  ]
+folds: [
+  {
+    type: ['comment', 'raw_string_literal']
+  }
+  {
+    start: {index: 0, type: '{'}
+    end: {index: -1, type: '}'}
+  }
+  {
+    start: {index: 0, type: '['}
+    end: {index: -1, type: ']'}
+  }
+  {
+    start: {index: 0, type: '('}
+    end: {index: -1, type: ')'}
+  }
+]
 
 scopes:
   'ERROR': 'syntax-error'

--- a/grammars/tree-sitter-go.cson
+++ b/grammars/tree-sitter-go.cson
@@ -1,0 +1,63 @@
+id: 'go'
+name: 'Go'
+type: 'tree-sitter'
+parser: 'tree-sitter-go'
+
+fileTypes: [
+  'go'
+]
+
+comments:
+  start: '// '
+
+folds:
+  delimiters: [
+    ['{', '}']
+    ['(', ')']
+    ['[', ']']
+  ]
+
+  nodes: [
+    'comment'
+    'raw_string_literal'
+  ]
+
+scopes:
+  'ERROR': 'syntax-error'
+  'comment': 'comment.block'
+
+  '"var"': 'keyword.import'
+  '"type"': 'keyword.type'
+  '"func"': 'keyword.function'
+  '"const"': 'keyword.import'
+  '"struct"': 'keyword.struct'
+  '"import"': 'keyword.import'
+  '"package"': 'keyword.package'
+  '"map"': 'keyword.map'
+  '"chan"': 'keyword.chan'
+
+  'type_identifier': 'support.type'
+  'field_identifier': 'variable.other.object.property'
+  'package_identifier': 'entity.name.package'
+
+  '"if"': 'keyword.control'
+  '"for"': 'keyword.control'
+  '"else"': 'keyword.control'
+  '"case"': 'keyword.control'
+  '"break"': 'keyword.control'
+  '"switch"': 'keyword.control'
+  '"select"': 'keyword.control'
+  '"return"': 'keyword.control'
+  '"default"': 'keyword.control'
+  '"continue"': 'keyword.control'
+
+  'interpreted_string_literal': 'string.quoted.double'
+  'raw_string_literal': 'string.quoted.double'
+  'rune_literal': 'constant.other.rune'
+  'int_literal': 'constant.numeric.integer'
+  'nil': 'constant.language.nil'
+
+  'call_expression > identifier': 'entity.name.function'
+  'function_declaration > identifier': 'entity.name.function'
+  'method_declaration > field_identifier': 'entity.name.function'
+  'call_expression > selector_expression > field_identifier': 'entity.name.function'

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/atom/language-go/issues"
   },
   "dependencies": {
-    "tree-sitter-go": "^0.5.1"
+    "tree-sitter-go": "^0.6.0"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "language-go",
   "description": "Go language support in Atom",
-  "version": "0.45.0-3",
+  "version": "0.45.0-4",
   "license": "MIT",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "language-go",
   "description": "Go language support in Atom",
-  "version": "0.45.0-1",
+  "version": "0.45.0-2",
   "license": "MIT",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/atom/language-go/issues"
   },
   "dependencies": {
-    "tree-sitter-go": "^0.5.0"
+    "tree-sitter-go": "^0.5.1"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "language-go",
   "description": "Go language support in Atom",
-  "version": "0.44.2",
+  "version": "0.45.0-0",
   "license": "MIT",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "bugs": {
     "url": "https://github.com/atom/language-go/issues"
   },
+  "dependencies": {
+    "tree-sitter-go": "^0.5.0"
+  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "language-go",
   "description": "Go language support in Atom",
-  "version": "0.45.0-0",
+  "version": "0.45.0-1",
   "license": "MIT",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "language-go",
   "description": "Go language support in Atom",
-  "version": "0.45.0-2",
+  "version": "0.45.0-3",
   "license": "MIT",
   "engines": {
     "atom": "*",


### PR DESCRIPTION
⚠️  Work In Progress ⚠️ 

This adds alternative grammars that uses [tree-sitter-go](https://github.com/tree-sitter/tree-sitter-go) for parsing instead of [first-mate](https://github.com/atom/first-mate).