### PR TITLE
Add support for Go module and checksum files

### DIFF
--- a/grammars/gomod.cson
+++ b/grammars/gomod.cson
@@ -5,22 +5,27 @@
 ]
 'patterns': [
   {
+    'comment': 'Module keyword'
     'match': '\\bmodule\\b'
     'name': 'keyword.module.module'
   }
   {
+    'comment': 'Require keyword'
     'match': '\\brequire\\b'
     'name': 'keyword.module.require'
   }
   {
+    'comment': 'Replace keyword'
     'match': '\\breplace\\b'
     'name': 'keyword.module.replace'
   }
   {
+    'comment': 'Exclude keyword'
     'match': '\\bexclude\\b'
     'name': 'keyword.module.exclude'
   }
   {
+    'comment': 'Version string'
     'match': 'v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:\\-(\\d{4}(?:0[1-9]|1[0-2])(?:0[1-9]|[1-2]\\d|3[0-1])(?:[0-1]\\d|2[0-3])(?:[0-5]\\d)(?:[0-5]\\d)))?(?:\\-([a-zA-Z\\d]{12}))?(?:\\+(incompatible))?'
     'name': 'string.unquoted.version.go'
   }
@@ -39,7 +44,7 @@
       }
     ]
   }
-  { 
+  {
     'begin': '//'
     'beginCaptures':
       '0':

--- a/grammars/gomod.cson
+++ b/grammars/gomod.cson
@@ -1,0 +1,9 @@
+'scopeName': 'source.mod'
+'name': 'Go module file'
+'fileTypes': [
+  'mod'
+]
+'patterns': [
+  {
+  }
+]

--- a/grammars/gomod.cson
+++ b/grammars/gomod.cson
@@ -35,4 +35,12 @@
       }
     ]
   }
+  { 
+    'begin': '//'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.comment.go'
+    'end': '$'
+    'name': 'comment.line.double-slash.go'
+  }
 ]

--- a/grammars/gomod.cson
+++ b/grammars/gomod.cson
@@ -21,6 +21,10 @@
     'name': 'keyword.module.exclude'
   }
   {
+    'match': 'v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:\\-(\\d{4}(?:0[1-9]|1[0-2])(?:0[1-9]|[1-2]\\d|3[0-1])(?:[0-1]\\d|2[0-3])(?:[0-5]\\d)(?:[0-5]\\d)))?(?:\\-([a-zA-Z\\d]{12}))?(?:\\+(incompatible))?'
+    'name': 'string.unquoted.version.go'
+  }
+  {
     'begin': '\\('
     'beginCaptures':
       '0':

--- a/grammars/gomod.cson
+++ b/grammars/gomod.cson
@@ -1,9 +1,38 @@
 'scopeName': 'source.mod'
-'name': 'Go module file'
+'name': 'Go Module File'
 'fileTypes': [
   'mod'
 ]
 'patterns': [
   {
+    'match': '\\bmodule\\b'
+    'name': 'keyword.module.module'
+  }
+  {
+    'match': '\\brequire\\b'
+    'name': 'keyword.module.require'
+  }
+  {
+    'match': '\\breplace\\b'
+    'name': 'keyword.module.replace'
+  }
+  {
+    'match': '\\bexclude\\b'
+    'name': 'keyword.module.exclude'
+  }
+  {
+    'begin': '\\('
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.begin.bracket.round.go'
+    'end': '\\)'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.end.bracket.round.go'
+    'patterns': [
+      {
+        'include': '$self'
+      }
+    ]
   }
 ]

--- a/grammars/gosum.cson
+++ b/grammars/gosum.cson
@@ -1,0 +1,9 @@
+'scopeName': 'source.sum'
+'name': 'Go checksum File'
+'fileTypes': [
+  'sum'
+]
+'patterns': [
+  {
+  }
+]

--- a/grammars/gosum.cson
+++ b/grammars/gosum.cson
@@ -5,5 +5,13 @@
 ]
 'patterns': [
   {
+    'comment': 'Version string'
+    'match': 'v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:\\-(\\d{4}(?:0[1-9]|1[0-2])(?:0[1-9]|[1-2]\\d|3[0-1])(?:[0-1]\\d|2[0-3])(?:[0-5]\\d)(?:[0-5]\\d)))?(?:\\-([a-zA-Z\\d]{12}))?(?:\\+(incompatible))?(\\/go\\.mod)?'
+    'name': 'string.unquoted.version.gosum'
+  }
+  {
+    'comment': 'Checksum'
+    'match': 'h1:[a-zA-Z\\d+\\/]{43}='
+    'name': 'string.unquoted.checksum.gosum'
   }
 ]

--- a/grammars/gosum.cson
+++ b/grammars/gosum.cson
@@ -1,5 +1,5 @@
 'scopeName': 'source.sum'
-'name': 'Go checksum File'
+'name': 'Go Checksum File'
 'fileTypes': [
   'sum'
 ]


### PR DESCRIPTION
### Description of the Change

In Go 1.11 a new language feature was added called `modules`. These exist to support removing `$GOPATH`, encourage repeatable builds and semantic versioning your Go packages.  If you want to dig further into what they are, I think the Go team did a great job in their [documentation](https://golang.org/cmd/go/#hdr-Modules__module_versions__and_more) and in the community [wiki](https://github.com/golang/go/wiki/Modules).

This particular change to the Atom `language-go` package is to add the two new file types that `modules` introduced. 

Those files are:

- A checksum file (which has an extension of `.sum`) 
- A module file (which has an extension of `.mod`)

### Alternate Designs

No particular alternatives stood out. 

### Benefits

When viewing module and checksum files the version numbers will be highlighted along with the commit hashes. There's some other stuff - like keyword highlighting - that makes it feel a little more polished. 

### Possible Drawbacks

More regular expressions to maintain for version numbers and checksums. 

### Applicable Issues

#152  - huge thank you to @pd93 for working on this with me 
