### PR TITLE
fixed go's function declaration syntax rule

### DIFF
--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -80,7 +80,7 @@
   }
   {
     'comment': 'Function declarations'
-    'match': '^(\\bfunc\\b)(?:\\s+(\\([^\\)]+\\)\\s+)?(\\w+)(?=\\())?'
+    'match': '^(\\bfunc\\b)(?:\\s+(\\([^\\)]+\\)\\s+)?(\\w+)\\s*(?=\\())?'
     'captures':
       '1':
         'name': 'keyword.function.go'

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -191,7 +191,7 @@ describe 'Go grammar', ->
         expect(tokens[0].scopes).toEqual ['source.go', scope]
 
   it 'tokenizes func regardless of the context', ->
-    funcKeyword = ['func f()', 'func (x) f()', 'func(x) f()', 'func']
+    funcKeyword = ['func f()', 'func (x) f()', 'func(x) f()', 'func', 'func f ()', 'func (x) f ()', 'func(x) f ()']
     for line in funcKeyword
       {tokens} = grammar.tokenizeLine line
       expect(tokens[0].value).toEqual 'func'


### PR DESCRIPTION
> __NOTE__<br>
> This PR is actually the [#142](https://github.com/atom/language-go/pull/142). I lost it on the issues lists for almost 2 years! and now that I'm back I couldn't find the base repo that I had for making this PR and therefore I closed the previous one and made a new PR. Hope it's not that confusing :D 
><br>


The grammar used to highlight function declaration syntax is designed to support only formatted code, which works great:

<img width="348" alt="screen shot 2017-11-02 at 11 57 37 pm" src="https://user-images.githubusercontent.com/2157285/32349237-9357c41c-c02b-11e7-992b-799df73d0529.png">

But for people who may prefer custom coding style or for when they're only typing not well formatted code the declaration syntax is not working because the optional white spacing is forgotten between function name and left parentheses as such:

<img width="769" alt="screen shot 2017-11-02 at 11 57 14 pm" src="https://user-images.githubusercontent.com/2157285/32349232-90d851d4-c02b-11e7-88f7-f8c61ac599d9.png">

This PR adds a tiny `\s*` in between of function name and the ending lookahead phrase to make sure all codes render right