### PR TITLE
Add support for changes to number literals introduced in Go 1.13

### DIFF
--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -124,14 +124,69 @@
         ]
   }
   {
-    'comment': 'Floating-point literals'
-    'match': '(\\.\\d+([Ee][\-\+]\\d+)?i?)\\b|\\b\\d+\\.\\d*(([Ee][\-\+]\\d+)?i?\\b)?'
-    'name': 'constant.numeric.floating-point.go'
+    'comment': 'Decimal literals'
+    'match': '(?<=[^_.\\da-zA-Z])(0|[1-9](_?\\d(_?\\d)*)?)(?=[^_.\\da-zA-Z])'
+    'name': 'constant.numeric.integer.decimal.go'
   }
   {
-    'comment': 'Integers'
-    'match': '\\b((0x[0-9a-fA-F]+)|(0[0-7]+i?)|(\\d+([Ee]\\d+)?i?)|(\\d+[Ee][\-\+]\\d+i?))\\b'
-    'name': 'constant.numeric.integer.go'
+    'comment': 'Binary literals'
+    'match': '(?<=[^_.\\da-zA-Z])0[bB]_?[01](_?[01])*(?=[^_.\\da-zA-Z])'
+    'name': 'constant.numeric.integer.binary.go'
+  }
+  {
+    'comment': 'Octal literals'
+    'match': '(?<=[^_.\\da-zA-Z])0[oO]?_?[0-7](_?[0-7])*(?=[^_.\\da-zA-Z])'
+    'name': 'constant.numeric.integer.octal.go'
+  }
+  {
+    'comment': 'Hexadecimal literals'
+    'match': '(?<=[^_.\\da-zA-Z])0[xX]_?[\\da-fA-F](_?[\\da-fA-F])*(?=[^_.\\da-zA-Z])'
+    'name': 'constant.numeric.integer.hexadecimal.go'
+  }
+  {
+    'comment': 'Decimal floating-point literals'
+    'match': '(?<=[^_.\\da-zA-Z])(\\d(_?\\d)*\\.(\\d(_?\\d)*)?([eE][+-]?\\d(_?\\d)*)?|\\d(_?\\d)*[eE][+-]?\\d(_?\\d)*|\\.\\d(_?\\d)*([eE][+-]?\\d(_?\\d)*)?)(?=[^_.\\da-zA-Z])'
+    'name': 'constant.numeric.floating-point.decimal.go'
+  }
+  {
+    'comment': 'Hexadecimal floating-point literals'
+    'match': '(?<=[^_.\\da-zA-Z])(0[xX](_?[\\da-fA-F](_?[\\da-fA-F])*\\.([\\da-fA-F](_?[\\da-fA-F])*)?|_?[\\da-fA-F](_?[\\da-fA-F])*|\\.[\\da-fA-F](_?[\\da-fA-F])*)[pP][+-]?\\d(_?\\d)*)(?=[^_.\\da-zA-Z])'
+    'name': 'constant.numeric.floating-point.hexadecimal.go'
+  }
+  {
+    'comment': 'Imaginary literals (with decimal integer literal)'
+    'match': '(?<=[^_.\\da-zA-Z])(0|[1-9](_?\\d(_?\\d)*)?)i(?=[^_.\\da-zA-Z])'
+    'name': 'constant.numeric.imaginary.decimal-integer.go'
+  }
+  {
+    'comment': 'Imaginary literals (with binary integer literal)'
+    'match': '(?<=[^_.\\da-zA-Z])0[bB]_?[01](_?[01])*i(?=[^_.\\da-zA-Z])'
+    'name': 'constant.numeric.imaginary.binary-integer.go'
+  }
+  {
+    'comment': 'Imaginary literals (with octal integer literal)'
+    'match': '(?<=[^_.\\da-zA-Z])0[oO]_?[0-7](_?[0-7])*i(?=[^_.\\da-zA-Z])'
+    'name': 'constant.numeric.imaginary.octal-integer.go'
+  }
+  {
+    'comment': 'Imaginary literals (with hexadecimal integer literal)'
+    'match': '(?<=[^_.\\da-zA-Z])0[xX]_?[\\da-fA-F](_?[\\da-fA-F])*i(?=[^_.\\da-zA-Z])'
+    'name': 'constant.numeric.imaginary.hexadecimal-integer.go'
+  }
+  {
+    'comment': 'Imaginary literals (with decimal floating-point literal)'
+    'match': '(?<=[^_.\\da-zA-Z])(\\d(_?\\d)*\\.(\\d(_?\\d)*)?([eE][+-]?\\d(_?\\d)*)?|\\d(_?\\d)*[eE][+-]?\\d(_?\\d)*|\\.\\d(_?\\d)*([eE][+-]?\\d(_?\\d)*)?)i(?=[^_.\\da-zA-Z])'
+    'name': 'constant.numeric.imaginary.decimal-floating-point.go'
+  }
+  {
+    'comment': 'Imaginary literals (with hexadecimal floating-point literal)'
+    'match': '(?<=[^_.\\da-zA-Z])(0[xX](_?[\\da-fA-F](_?[\\da-fA-F])*\\.([\\da-fA-F](_?[\\da-fA-F])*)?|_?[\\da-fA-F](_?[\\da-fA-F])*|\\.[\\da-fA-F](_?[\\da-fA-F])*)[pP][+-]?\\d(_?\\d)*)i(?=[^_.\\da-zA-Z])'
+    'name': 'constant.numeric.imaginary.hexadecimal-floating-point.go'
+  }
+  {
+    'comment': 'Imaginary literals (for backwards compatibility)'
+    'match': '(?<=[^_.\\da-zA-Z])0+(_?\\d)*i(?=[^_.\\da-zA-Z])'
+    'name': 'constant.numeric.imaginary.backwards-compatibility.go'
   }
   {
     'comment': 'Language constants'

--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -125,67 +125,67 @@
   }
   {
     'comment': 'Decimal literals'
-    'match': '(?<=[^_.\\da-zA-Z])(0|[1-9](_?\\d(_?\\d)*)?)(?=[^_.\\da-zA-Z])'
+    'match': '(^|(?<=[^_.\\da-zA-Z]))(0|[1-9](_?\\d(_?\\d)*)?)(?=[^_.\\da-zA-Z])'
     'name': 'constant.numeric.integer.decimal.go'
   }
   {
     'comment': 'Binary literals'
-    'match': '(?<=[^_.\\da-zA-Z])0[bB]_?[01](_?[01])*(?=[^_.\\da-zA-Z])'
+    'match': '(^|(?<=[^_.\\da-zA-Z]))0[bB]_?[01](_?[01])*(?=[^_.\\da-zA-Z])'
     'name': 'constant.numeric.integer.binary.go'
   }
   {
     'comment': 'Octal literals'
-    'match': '(?<=[^_.\\da-zA-Z])0[oO]?_?[0-7](_?[0-7])*(?=[^_.\\da-zA-Z])'
+    'match': '(^|(?<=[^_.\\da-zA-Z]))0[oO]?_?[0-7](_?[0-7])*(?=[^_.\\da-zA-Z])'
     'name': 'constant.numeric.integer.octal.go'
   }
   {
     'comment': 'Hexadecimal literals'
-    'match': '(?<=[^_.\\da-zA-Z])0[xX]_?[\\da-fA-F](_?[\\da-fA-F])*(?=[^_.\\da-zA-Z])'
+    'match': '(^|(?<=[^_.\\da-zA-Z]))0[xX]_?[\\da-fA-F](_?[\\da-fA-F])*(?=[^_.\\da-zA-Z])'
     'name': 'constant.numeric.integer.hexadecimal.go'
   }
   {
     'comment': 'Decimal floating-point literals'
-    'match': '(?<=[^_.\\da-zA-Z])(\\d(_?\\d)*\\.(\\d(_?\\d)*)?([eE][+-]?\\d(_?\\d)*)?|\\d(_?\\d)*[eE][+-]?\\d(_?\\d)*|\\.\\d(_?\\d)*([eE][+-]?\\d(_?\\d)*)?)(?=[^_.\\da-zA-Z])'
+    'match': '(^|(?<=[^_.\\da-zA-Z]))(\\d(_?\\d)*\\.(\\d(_?\\d)*)?([eE][+-]?\\d(_?\\d)*)?|\\d(_?\\d)*[eE][+-]?\\d(_?\\d)*|\\.\\d(_?\\d)*([eE][+-]?\\d(_?\\d)*)?)(?=[^_.\\da-zA-Z])'
     'name': 'constant.numeric.floating-point.decimal.go'
   }
   {
     'comment': 'Hexadecimal floating-point literals'
-    'match': '(?<=[^_.\\da-zA-Z])(0[xX](_?[\\da-fA-F](_?[\\da-fA-F])*\\.([\\da-fA-F](_?[\\da-fA-F])*)?|_?[\\da-fA-F](_?[\\da-fA-F])*|\\.[\\da-fA-F](_?[\\da-fA-F])*)[pP][+-]?\\d(_?\\d)*)(?=[^_.\\da-zA-Z])'
+    'match': '(^|(?<=[^_.\\da-zA-Z]))(0[xX](_?[\\da-fA-F](_?[\\da-fA-F])*\\.([\\da-fA-F](_?[\\da-fA-F])*)?|_?[\\da-fA-F](_?[\\da-fA-F])*|\\.[\\da-fA-F](_?[\\da-fA-F])*)[pP][+-]?\\d(_?\\d)*)(?=[^_.\\da-zA-Z])'
     'name': 'constant.numeric.floating-point.hexadecimal.go'
   }
   {
     'comment': 'Imaginary literals (with decimal integer literal)'
-    'match': '(?<=[^_.\\da-zA-Z])(0|[1-9](_?\\d(_?\\d)*)?)i(?=[^_.\\da-zA-Z])'
+    'match': '(^|(?<=[^_.\\da-zA-Z]))(0|[1-9](_?\\d(_?\\d)*)?)i(?=[^_.\\da-zA-Z])'
     'name': 'constant.numeric.imaginary.decimal-integer.go'
   }
   {
     'comment': 'Imaginary literals (with binary integer literal)'
-    'match': '(?<=[^_.\\da-zA-Z])0[bB]_?[01](_?[01])*i(?=[^_.\\da-zA-Z])'
+    'match': '(^|(?<=[^_.\\da-zA-Z]))0[bB]_?[01](_?[01])*i(?=[^_.\\da-zA-Z])'
     'name': 'constant.numeric.imaginary.binary-integer.go'
   }
   {
     'comment': 'Imaginary literals (with octal integer literal)'
-    'match': '(?<=[^_.\\da-zA-Z])0[oO]_?[0-7](_?[0-7])*i(?=[^_.\\da-zA-Z])'
+    'match': '(^|(?<=[^_.\\da-zA-Z]))0[oO]_?[0-7](_?[0-7])*i(?=[^_.\\da-zA-Z])'
     'name': 'constant.numeric.imaginary.octal-integer.go'
   }
   {
     'comment': 'Imaginary literals (with hexadecimal integer literal)'
-    'match': '(?<=[^_.\\da-zA-Z])0[xX]_?[\\da-fA-F](_?[\\da-fA-F])*i(?=[^_.\\da-zA-Z])'
+    'match': '(^|(?<=[^_.\\da-zA-Z]))0[xX]_?[\\da-fA-F](_?[\\da-fA-F])*i(?=[^_.\\da-zA-Z])'
     'name': 'constant.numeric.imaginary.hexadecimal-integer.go'
   }
   {
     'comment': 'Imaginary literals (with decimal floating-point literal)'
-    'match': '(?<=[^_.\\da-zA-Z])(\\d(_?\\d)*\\.(\\d(_?\\d)*)?([eE][+-]?\\d(_?\\d)*)?|\\d(_?\\d)*[eE][+-]?\\d(_?\\d)*|\\.\\d(_?\\d)*([eE][+-]?\\d(_?\\d)*)?)i(?=[^_.\\da-zA-Z])'
+    'match': '(^|(?<=[^_.\\da-zA-Z]))(\\d(_?\\d)*\\.(\\d(_?\\d)*)?([eE][+-]?\\d(_?\\d)*)?|\\d(_?\\d)*[eE][+-]?\\d(_?\\d)*|\\.\\d(_?\\d)*([eE][+-]?\\d(_?\\d)*)?)i(?=[^_.\\da-zA-Z])'
     'name': 'constant.numeric.imaginary.decimal-floating-point.go'
   }
   {
     'comment': 'Imaginary literals (with hexadecimal floating-point literal)'
-    'match': '(?<=[^_.\\da-zA-Z])(0[xX](_?[\\da-fA-F](_?[\\da-fA-F])*\\.([\\da-fA-F](_?[\\da-fA-F])*)?|_?[\\da-fA-F](_?[\\da-fA-F])*|\\.[\\da-fA-F](_?[\\da-fA-F])*)[pP][+-]?\\d(_?\\d)*)i(?=[^_.\\da-zA-Z])'
+    'match': '(^|(?<=[^_.\\da-zA-Z]))(0[xX](_?[\\da-fA-F](_?[\\da-fA-F])*\\.([\\da-fA-F](_?[\\da-fA-F])*)?|_?[\\da-fA-F](_?[\\da-fA-F])*|\\.[\\da-fA-F](_?[\\da-fA-F])*)[pP][+-]?\\d(_?\\d)*)i(?=[^_.\\da-zA-Z])'
     'name': 'constant.numeric.imaginary.hexadecimal-floating-point.go'
   }
   {
     'comment': 'Imaginary literals (for backwards compatibility)'
-    'match': '(?<=[^_.\\da-zA-Z])0+(_?\\d)*i(?=[^_.\\da-zA-Z])'
+    'match': '(^|(?<=[^_.\\da-zA-Z]))0+(_?\\d)*i(?=[^_.\\da-zA-Z])'
     'name': 'constant.numeric.imaginary.backwards-compatibility.go'
   }
   {

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -285,11 +285,19 @@ describe 'Go grammar', ->
 
   it 'tokenizes numerics', ->
     numbers =
-      'constant.numeric.integer.go': ['42', '0600', '0xBadFace', '170141183460469231731687303715884105727', '1E6', '0i', '011i', '1E6i']
-      'constant.numeric.floating-point.go': [
-        '0.', '72.40', '072.40', '2.71828', '1.e+0', '6.67428e-11', '.25', '.12345E+5',
-        '0.i', '2.71828i', '1.e+0i', '6.67428e-11i', '.25i', '.12345E+5i'
-      ]
+      'constant.numeric.integer.decimal.go': ['10', '4_2', '170141183460469231731687303715884105727', '170_141183_460469_231731_687303_715884_105727']
+      'constant.numeric.integer.binary.go': ['0b1011', '0b1011', '0b1011_1011', '0B10_11_10_11']
+      'constant.numeric.integer.octal.go': ['0600', '0_600', '0o600', '0O600']
+      'constant.numeric.integer.hexadecimal.go': ['0xBadFace', '0xBad_Face', '0x_67_7a_2f_cc_40_c6', '0XBadFace', '0XBad_Face', '0X_67_7a_2f_cc_40_c6']
+      'constant.numeric.floating-point.decimal.go': ['0.', '72.40', '072.40', '2.71828', '1.e+0', '6.67428e-11', '1E6', '1.25', '.25', '.12345E+5', '.12345E-5', '.12345E5', '1_5.', '1_5.123', '0.15e+0_2']
+      'constant.numeric.floating-point.hexadecimal.go': ['0x1p-2', '0x2.p10', '0x1.Fp+0', '0X.8p-0', '0X_1FFFP-16']
+      'constant.numeric.imaginary.decimal-integer.go': ['0i', '12i', '89i']
+      'constant.numeric.imaginary.binary-integer.go': ['0b111i', '0B111i', '0b1_11i', '0B1_11i', '0b1_1_1i', '0B1_1_1i']
+      'constant.numeric.imaginary.octal-integer.go': ['0123i', '0o123i', '0O123i', '01_23i', '0o1_23i', '0O1_23i']
+      'constant.numeric.imaginary.hexadecimal-integer.go': ['0xabci', '0Xabci', '0xa_bci', '0Xa_bci', '0xa_b_ci', '0Xa_b_ci']
+      'constant.numeric.imaginary.decimal-floating-point.go': ['0.i', '2.71828i', '1.e+0i', '6.67428e-11i', '1E6i', '.25i', '.12345E+5i', '00.i', '02.71828i', '01.e+0i', '06.67428e-11i', '01E6i', '00.25i', '00.12345E+5i']
+      'constant.numeric.imaginary.hexadecimal-floating-point.go': ['0x1p-2i', '0x1p-2i', '0x2.p10i', '0x1.Fp+0i', '0X.8p-0i', '0X_1FFFP-16i']
+      'constant.numeric.imaginary.backwards-compatibility.go': ['089i', '0089i', '0_0_89i', '0_0_8_9i', '012i', '0012i', '0_0_12i', '0_0_1_2i', '000i', '000123i']
 
     for scope, nums of numbers
       for num in nums
@@ -355,10 +363,10 @@ describe 'Go grammar', ->
 
   it 'does not treat values/variables attached to comparion operators as extensions of the operator', ->
     {tokens} = grammar.tokenizeLine '2<3.0 && 12>bar'
-    expect(tokens[0]).toEqual value: '2', scopes: ['source.go', 'constant.numeric.integer.go']
+    expect(tokens[0]).toEqual value: '2', scopes: ['source.go', 'constant.numeric.integer.decimal.go']
     expect(tokens[1]).toEqual value: '<', scopes: ['source.go', 'keyword.operator.comparison.go']
-    expect(tokens[2]).toEqual value: '3.0', scopes: ['source.go', 'constant.numeric.floating-point.go']
-    expect(tokens[6]).toEqual value: '12', scopes: ['source.go', 'constant.numeric.integer.go']
+    expect(tokens[2]).toEqual value: '3.0', scopes: ['source.go', 'constant.numeric.floating-point.decimal.go']
+    expect(tokens[6]).toEqual value: '12', scopes: ['source.go', 'constant.numeric.integer.decimal.go']
     expect(tokens[7]).toEqual value: '>', scopes: ['source.go', 'keyword.operator.comparison.go']
     expect(tokens[8]).toEqual value: 'bar', scopes: ['source.go']
 
@@ -522,7 +530,7 @@ describe 'Go grammar', ->
 
     testNum = (token, value) ->
       expect(token.value).toBe value
-      expect(token.scopes).toEqual ['source.go', 'constant.numeric.integer.go']
+      expect(token.scopes).toEqual ['source.go', 'constant.numeric.integer.decimal.go']
 
     testString = (token, value) ->
       expect(token.value).toBe value
@@ -594,7 +602,7 @@ describe 'Go grammar', ->
         testVar tokens[0]
         testVarDeclaration tokens[2], 's'
         expect(tokens[4]).toEqual value: '[', scopes: ['source.go', 'punctuation.definition.bracket.square.go']
-        expect(tokens[5]).toEqual value: '4', scopes: ['source.go', 'constant.numeric.integer.go']
+        expect(tokens[5]).toEqual value: '4', scopes: ['source.go', 'constant.numeric.integer.decimal.go']
         expect(tokens[6]).toEqual value: ']', scopes: ['source.go', 'punctuation.definition.bracket.square.go']
         testStringType tokens[7], 'string'
 

--- a/spec/go-spec.coffee
+++ b/spec/go-spec.coffee
@@ -293,11 +293,11 @@ describe 'Go grammar', ->
       'constant.numeric.floating-point.hexadecimal.go': ['0x1p-2', '0x2.p10', '0x1.Fp+0', '0X.8p-0', '0X_1FFFP-16']
       'constant.numeric.imaginary.decimal-integer.go': ['0i', '12i', '89i']
       'constant.numeric.imaginary.binary-integer.go': ['0b111i', '0B111i', '0b1_11i', '0B1_11i', '0b1_1_1i', '0B1_1_1i']
-      'constant.numeric.imaginary.octal-integer.go': ['0123i', '0o123i', '0O123i', '01_23i', '0o1_23i', '0O1_23i']
+      'constant.numeric.imaginary.octal-integer.go': ['0o123i', '0O123i', '0o1_23i', '0O1_23i']
       'constant.numeric.imaginary.hexadecimal-integer.go': ['0xabci', '0Xabci', '0xa_bci', '0Xa_bci', '0xa_b_ci', '0Xa_b_ci']
       'constant.numeric.imaginary.decimal-floating-point.go': ['0.i', '2.71828i', '1.e+0i', '6.67428e-11i', '1E6i', '.25i', '.12345E+5i', '00.i', '02.71828i', '01.e+0i', '06.67428e-11i', '01E6i', '00.25i', '00.12345E+5i']
       'constant.numeric.imaginary.hexadecimal-floating-point.go': ['0x1p-2i', '0x1p-2i', '0x2.p10i', '0x1.Fp+0i', '0X.8p-0i', '0X_1FFFP-16i']
-      'constant.numeric.imaginary.backwards-compatibility.go': ['089i', '0089i', '0_0_89i', '0_0_8_9i', '012i', '0012i', '0_0_12i', '0_0_1_2i', '000i', '000123i']
+      'constant.numeric.imaginary.backwards-compatibility.go': ['0123i', '01_23i', '0123i', '00123i', '0_0_123i', '0_0_1_23i', '000i', '089i', '0089i', '0_0_89i', '0_0_8_9i']
 
     for scope, nums of numbers
       for num in nums


### PR DESCRIPTION
### Requirements

The updated grammar should support syntax highlighting for the following:

> * **Binary integer literals**: The prefix `0b` or `0B` indicates a binary integer literal such as `0b1011`.
> * **Octal integer literals**: The prefix `0o` or `0O` indicates an octal integer literal such as `0o660`. The existing octal notation indicated by a leading `0` followed by octal digits remains valid.
> * **Hexadecimal floating point literals** The prefix `0x` or `0X` may now be used to express the mantissa of a floating-point number in hexadecimal format such as `0x1.0p-1021`. A hexadecimal floating-point number must always have an exponent, written as the letter p or P followed by an exponent in decimal. The exponent scales the mantissa by 2 to the power of the exponent.
> * **Imaginary literals**: The imaginary suffix `i` may now be used with any (binary, decimal, hexadecimal) integer or floating-point literal.
> * **Digit separators**: The digits of any number literal may now be separated (grouped) using underscores, such as in `1_000_000`, `0b_1010_0110`, or `3.1415_9265`. An underscore may appear between any two digits or the literal prefix and the first digit.

(taken from [Go 1.13 Release Notes](https://golang.org/doc/go1.13#language))

### Description of the Change

All the regular expressions are manually converted from the [EBNF (Extended Backus-Naur Form)](https://golang.org/ref/spec#Notation) expressions for each number literal type found in [The Go Programming Language Specification](https://golang.org/ref/spec):

- [Integer literals](https://golang.org/ref/spec#Integer_literals)
- [Floating-point literals](https://golang.org/ref/spec#Floating-point_literals)
- [Imaginary literals](https://golang.org/ref/spec#Imaginary_literals)

Playground containing code snippet to test with: https://play.golang.org/p/IuWyvmHjHs0

---

#### EBNF to Regular Expression Conversion

**Decimal literals**

| Type | EBNF | Regex |
| --- | --- | --- |
| decimal_digit  | `"0" … "9" .`                                       | `/\d/`                    |
| decimal_digits | `decimal_digit { [ "_" ] decimal_digit } .`         | `/\d(_?\d)*/`             |
| decimal_lit    | `"0" \| ( "1" … "9" ) [ [ "_" ] decimal_digits ] .` | `/0\|[1-9](_?\d(_?\d)*)?/` |

**Binary literals**

| Type | EBNF | Regex |
| --- | --- | --- |
| binary_digit   | `"0" \| "1" .`                                      | `/[01]/`                 |
| binary_digits  | `binary_digit { [ "_" ] binary_digit } .`           | `/[01](_?[01])*/`        |
| binary_lit     | `"0" ( "b" \| "B" ) [ "_" ] binary_digits .`        | `/0[bB]_?[01](_?[01])*/` |

**Octal literals**

| Type | EBNF | Regex |
| --- | --- | --- |
| octal_digit    | `"0" … "7" .`                                       | `/[0-7]/`                   |
| octal_digits   | `octal_digit { [ "_" ] octal_digit } .`             | `/[0-7](_?[0-7])*/`         |
| octal_lit      | `"0" [ "o" \| "O" ] [ "_" ] octal_digits .`         | `/0[oO]?_?[0-7](_?[0-7])*/` |

**Hexadecimal literals**

| Type | EBNF | Regex |
| --- | --- | --- |
| hex_digit      | `"0" … "9" \| "A" … "F" \| "a" … "f" .`             | `/[\da-fA-F]/`                       |
| hex_digits     | `hex_digit { [ "_" ] hex_digit } .`                 | `/[\da-fA-F](_?[\da-fA-F])*/`        |
| hex_lit        | `"0" ( "x" \| "X" ) [ "_" ] hex_digits .`           | `/0[xX]_?[\da-fA-F](_?[\da-fA-F])*/` |

**Decimal floating-point literals**

| Type | EBNF | Regex |
| --- | --- | --- |
| decimal_exponent        | `( "e" \| "E" ) [ "+" \| "-" ] decimal_digits .`               | `/[eE][+-]?\d(_?\d)*/`                           |
| decimal_float_lit (I)   | `decimal_digits "." [ decimal_digits ] [ decimal_exponent ] .` | `/\d(_?\d)*\.(\d(_?\d)*)?([eE][+-]?\d(_?\d)*)?/` |
| decimal_float_lit (II)  | `decimal_digits decimal_exponent .`                            | `/\d(_?\d)*[eE][+-]?\d(_?\d)*/`                  |
| decimal_float_lit (III) | `"." decimal_digits [ decimal_exponent ] .`                    | `/\.\d(_?\d)*([eE][+-]?\d(_?\d)*)?/`             |

**Hexadecimal floating-point literals**

| Type | EBNF | Regex |
| --- | --- | --- |
| hex_exponent       | `( "p" \| "P" ) [ "+" \| "-" ] decimal_digits .` | `/[pP][+-]?\d(_?\d)*/`                                        |
| hex_mantissa (I)   | `[ "_" ] hex_digits "." [ hex_digits ] .`        | `/_?[\da-fA-F](_?[\da-fA-F])*\.([\da-fA-F](_?[\da-fA-F])*)?/` |
| hex_mantissa (II)  | `[ "_" ] hex_digits .`                           | `/_?[\da-fA-F](_?[\da-fA-F])*/`                               |
| hex_mantissa (III) | `"." hex_digits .`                               | `/\.[\da-fA-F](_?[\da-fA-F])*/`                               |
| hex_float_lit      | `"0" ( "x" \| "X" ) hex_mantissa hex_exponent .` | `/0[xX](_?[\da-fA-F](_?[\da-fA-F])*\.([\da-fA-F](_?[\da-fA-F])*)?\|_?[\da-fA-F](_?[\da-fA-F])*\|\.[\da-fA-F](_?[\da-fA-F])*)[pP][+-]?\d(_?\d)*/` |

**Imaginary literals**

Since the imaginary suffix `i` may now be used with any (binary, decimal, hexadecimal) integer or floating-point literal, we just need to append an `i` to the various set of regular expressions above.

There's only a slight difference in the pattern for imaginary literals (with octal integer literal), which we modify it to not collide with the old imaginary literals pattern (pre Go 1.12):

```diff
  {
    'comment': 'Imaginary literals (with octal integer literal)'
-   'match': '(^|(?<=[^_.\\da-zA-Z]))0[oO]?_?[0-7](_?[0-7])*i(?=[^_.\\da-zA-Z])'
+   'match': '(^|(?<=[^_.\\da-zA-Z]))0[oO]_?[0-7](_?[0-7])*i(?=[^_.\\da-zA-Z])'
    'name': 'constant.numeric.imaginary.octal-integer.go'
  }
  ...
+ {
+   'comment': 'Imaginary literals (for backwards compatibility)'
+   'match': '(^|(?<=[^_.\\da-zA-Z]))0+(_?\\d)*i(?=[^_.\\da-zA-Z])'
+   'name': 'constant.numeric.imaginary.backwards-compatibility.go'
+ }
```

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

<!-- What benefits will be realized by the code change? -->

Patterns & scopes have been broken down by each number literal types for the following benefits:

- Smaller regular expressions are easier to maintain & audit
- Imaginary literals becomes a first class citizen like in [tree-sitter/tree-sitter-go](https://github.com/tree-sitter/tree-sitter-go):
  - https://github.com/tree-sitter/tree-sitter-go/blob/master/corpus/literals.txt#L77
  - https://github.com/atom/language-go/blob/master/grammars/tree-sitter-go.cson#L85
- More detailed scopes would allows themes able to provide more "granular" syntax highlighting (eg. binary literals can be colored differently from decimal literals etc.)

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

This change introduces the following scopes:

- `constant.numeric.integer.decimal.go`
- `constant.numeric.integer.binary.go`
- `constant.numeric.integer.octal.go`
- `constant.numeric.integer.hexadecimal.go`
- `constant.numeric.floating-point.decimal.go`
- `constant.numeric.floating-point.hexadecimal.go`
- `constant.numeric.imaginary.decimal-integer.go`
- `constant.numeric.imaginary.binary-integer.go`
- `constant.numeric.imaginary.octal-integer.go`
- `constant.numeric.imaginary.hexadecimal-integer.go`
- `constant.numeric.imaginary.decimal-floating-point.go`
- `constant.numeric.imaginary.hexadecimal-floating-point.go`
- `constant.numeric.imaginary.backwards-compatibility.go`

The only "breaking" change I'm aware is that imaginary literal expressions currently matched under `constant.numeric.integer` would now be matched with scopes prefixed with `constant.numeric.imaginary.*`.

But as far as I know, majority of the color themes don't use anything beyond `constant.numeric`: https://github.com/search?l=Less&q=syntax--integer&type=Code

### Applicable Issues

<!-- Enter any applicable Issues here -->

Fixes #174
Related https://github.com/tree-sitter/tree-sitter-go/issues/31 (PR: https://github.com/tree-sitter/tree-sitter-go/pull/32)
