### PR TITLE
Support %w verb/placeholder

### DIFF
--- a/grammars/go.cson
+++ b/grammars/go.cson
@@ -530,7 +530,7 @@
   'string_placeholder':
     'patterns': [
       {
-        'match': '%(\\[\\d+\\])?([\\+#\\-0\\x20]{,2}((\\d+|\\*)?(\\.?(\\d+|\\*|(\\[\\d+\\])\\*?)?(\\[\\d+\\])?)?))?[vT%tbcdoqxXUbeEfFgGsp]'
+        'match': '%(\\[\\d+\\])?([\\+#\\-0\\x20]{,2}((\\d+|\\*)?(\\.?(\\d+|\\*|(\\[\\d+\\])\\*?)?(\\[\\d+\\])?)?))?[vT%tbcdoqxXUbeEfFgGspw]'
         'name': 'constant.other.placeholder.go'
       }
     ]


### PR DESCRIPTION
The `%w` verb is introduced into go 1.13 and is functionally an alias for `%v`, but adds wrapping to errors.

### Description of the Change

`w` added to the list of placeholder characters.

### Alternate Designs

n/a

### Benefits

proper highlighting of a newly-valid print verb

### Possible Drawbacks

conceivably people using older go versions might see a verb highlighted that won't actually work as a verb, but the odds are that if they are seeing / using %w, they are already using the correct version.

### Applicable Issues

n/a
